### PR TITLE
Removed isVulnerable check so vulnerabilities are written to log.

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -42,7 +42,7 @@ var hash = {
 };
 
 function printResults(file, results) {
-  if (retire.isVulnerable(results) || !config.verbose) return;
+  if (!config.verbose) return;
   var log = console.log;
   if (retire.isVulnerable(results)) {
     log = console.warn;


### PR DESCRIPTION
Vulnerabilities are now written to log with WARN level if verbose flag is true. Vulnerabilities were never written to log regardless of verbose flag, only files not containing vulnerabilities were written to log. This should now be fixed.
