### PR TITLE
Update README.md with global install switch

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -3,7 +3,7 @@ Command line scanner looking for use of known vulnerable js files and node modul
 Install
 -------
 
-    npm install retire
+    npm install -g retire
     
 
 Usage


### PR DESCRIPTION
To use retire it needs to be installed globally and requires the -g switch when installing
