### PR TITLE
Listed prototype.js 1.5.1.2 as safe per CVE-2008-7220

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -120,7 +120,8 @@
 	},
 	"prototypejs" : {
 		"vulnerabilities" : [
-			{ "below" : "1.6.0.2", "info" : [ "http://www.cvedetails.com/cve/CVE-2008-7220/" ] }
+			{ "atOrAbove" : "1.6.0", "below" : "1.6.0.2", "info" : [ "http://www.cvedetails.com/cve/CVE-2008-7220/" ] },
+			{ "below" : "1.5.1.2", "info" : [ "http://www.cvedetails.com/cve/CVE-2008-7220/" ] }
 		],
 		"extractors" : {
 			"uri"			: [ "/(§§version§§)/prototype(\\.min)?\\.js" ],


### PR DESCRIPTION
Listed prototype.js 1.5.1.2 as safe per CVE-2008-7220 - security fix was apparently backported to this version according to: http://prototypejs.org/2008/01/25/prototype-1-6-0-2-bug-fixes-performance-improvements-and-security/
