### PR TITLE
Fx 26: use CSP category for logging. This removes the [Read me] link in ...

### DIFF
--- a/firefox/lib/firefox.js
+++ b/firefox/lib/firefox.js
@@ -28,13 +28,13 @@ exports.toggleWebConsole = () => {
 // Fixme: make re-usable.
 function logToWebConsole(rmsg, details, windowId) {
   // Use nsIScriptError interface
-  // This can be replaced with devtools apis when the apis are ready.
+  // This should be replaced with devtools apis when the apis are ready.
   // See: https://bugzilla.mozilla.org/show_bug.cgi?id=843004.
   let consoleService = Cc["@mozilla.org/consoleservice;1"]
       .getService(Ci.nsIConsoleService);
   let scriptError = Cc["@mozilla.org/scripterror;1"]
       .createInstance(Ci.nsIScriptError);
-  let category = "Mixed Content Blocker"; // Use a security category. See comment above.
+  let category = "CSP"; // Use a security category. See comment above.
   let logMessage = "Loaded library with known vulnerability " + details.url + "\nSee this " + rmsg;
 
   scriptError.initWithWindowID(logMessage, details.url, null, null, null, scriptError.warningFlag, category, windowId);

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -5,7 +5,7 @@
   "description": "Scanning website for vulernable js libraries. Icon by http://www.studiomx.eu/",
   "author": "Erlend Oftedal",
   "license": "MPL 2.0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "icon": "data/icons/add-on-icon.png",
   "icon64": "data/icons/icon64.png"
 }


### PR DESCRIPTION
...the message text (fx 26).

Hopefully, we should be using a high-level api for this in the future (https://bugzilla.mozilla.org/show_bug.cgi?id=843004)
