### PR TITLE
fixed security warnings by upgrading request so that qs >= v1.0.0

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "commander"	     : "2.0.x",
     "read-installed" : "0.2.x",
     "walkdir"        : "0.0.7",
-    "request"        : "~2.27.0"
+    "request"        : "~2.40.0"
   },
   "devDependencies": {
     "nodeunit": "",


### PR DESCRIPTION
see https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking for details. v2.40.0 is the minimum fixed version.
