### PR TITLE
Added two non-recursive html sanitization issues

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -131,6 +131,12 @@
 	},
 	"ep_imageconvert" : {
 		"vulnerabilities" : [ { "below" : "0.0.3", "info" : [ "http://nodesecurity.io/advisories/ep_imageconvert_command_injection" ] } ]
-	}
+	},
+	"sanitize-html": {
+		"vulnerabilities" : [ { "below" : "1.4.3", "info" : [ "https://github.com/punkave/sanitize-html/issues/29" ] } ]
+	},	
+	"htmlparser2": {
+		"vulnerabilities" : [ { "below" : "3.7.4", "info" : [ "https://github.com/fb55/htmlparser2/issues/105" ] } ]
+	}	
 
 }


### PR DESCRIPTION
The module `sanitize-html` up to version 1.4.2 is susceptible to masking attacks in order to trick the sanitization. Root cause lies in `htmlparser2`up to at least 3.7.3 which does not work recursively until the result stops changing but only runs once. The former module is hotfixed with 1.4.3 while the latter is not fixed as of now.

Examples:
- `<<img src="csrf-attack"/>img src="csrf-attack"/>`sanitizes into `<img src="csrf-attack"/>`
- `<<script>alert("XSS3")</script>script>alert("XSS3")<</script>/script>`sanitizes into `<script>alert("XSS3")</script>`
