### PR TITLE
Updated retireignore to accept dependency ignores on '@'

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -66,7 +66,7 @@ if(config.ignorefile) {
     process.exit(1);
   }
   var lines = fs.readFileSync(config.ignorefile).toString().split(/\r\n|\n/g).filter(function(e) { return e !== ''; });
-  ignored = _.map(lines, function(e) { return path.resolve(e); });
+  ignored = _.map(lines, function(e) { return e[0] === '@' ? e.slice(1) : path.resolve(e); });
   config.ignore = config.ignore.concat(ignored);
 }
 

--- a/node/lib/scanner.js
+++ b/node/lib/scanner.js
@@ -49,7 +49,7 @@ function scanJsFile(file, repo, options) {
   var results = retire.scanFileName(file, repo);
   if (!retire.isVulnerable(results)) {
     results = retire.scanFileContent(fs.readFileSync(file), repo, hash);
-  }  
+  }
   printResults(file, results, options);
 }
 
@@ -60,6 +60,9 @@ function printParent(comp, options) {
 
 function scanDependencies(dependencies, nodeRepo, options) {
   for (var i in dependencies) {
+    if (options.ignore && shouldIgnore(dependencies[i].component, options.ignore)) {
+      return;
+    }
 		results = retire.scanNodeDependency(dependencies[i], nodeRepo);
 		if (retire.isVulnerable(results)) {
 			events.emit('vulnerable-dependency-found');


### PR DESCRIPTION
Adds the ability to add an '@' to the beginning of any line in the retireignore file which will prevent resolving as path and allow ignore to also apply to dependencies.
