### PR TITLE
htmlparser2 still vulnerable in 3.8.2

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -136,7 +136,7 @@
 		"vulnerabilities" : [ { "below" : "1.4.3", "info" : [ "https://github.com/punkave/sanitize-html/issues/29" ] } ]
 	},	
 	"htmlparser2": {
-		"vulnerabilities" : [ { "below" : "3.7.4", "info" : [ "https://github.com/fb55/htmlparser2/issues/105" ] } ]
+		"vulnerabilities" : [ { "below" : "3.8.3", "info" : [ "https://github.com/fb55/htmlparser2/issues/105" ] } ]
 	}	
 
 }


### PR DESCRIPTION
issue originally reported for 3.7.3 is not fixed yet
