### PR TITLE
Do not crash on malformed Bower json files

### DIFF
--- a/node/lib/scanner.js
+++ b/node/lib/scanner.js
@@ -76,10 +76,14 @@ function scanDependencies(dependencies, nodeRepo, options) {
 }
 
 function scanBowerFile(file, repo, options) {
+  try {
   var bower = JSON.parse(fs.readFileSync(file));
-  if (bower.version) {
-    var results = retire.check(bower.name, bower.version, repo);
-    printResults(file, results, options);
+    if (bower.version) {
+      var results = retire.check(bower.name, bower.version, repo);
+      printResults(file, results, options);
+    }
+  } catch (e) {
+    log(options).warn('Could not parse file: ' + file);
   }
 }
 


### PR DESCRIPTION
This fixes crash like this: `Exception caught:  { '0': [SyntaxError: Unexpected end of input] }`.

Ran across this analyzing  `.../node_modules/bower/node_modules/bower-json/test/pkg-bower-json-malformed/bower.json`.
