### PR TITLE
Fix multiple dependency resolving flaws

### DIFF
--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -17,9 +17,9 @@ function listdep(parent, filter, dep, level, deps) {
 			cyclic = false;
 			dep_parent = o.parent;
 			while (dep_parent != null) {
-				if (dep_parent.component == i) {
+				if (dep_parent.component === i) {
 					cyclic = true;
-					dep_parent = null;
+					break;
 				} else {
 					dep_parent = dep_parent.parent;
 				}


### PR DESCRIPTION
Found two issues, when analyzing larger project:
1) ran out of stack size: `Exception caught:  { '0': [RangeError: Maximum call stack size exceeded] }`
2) got infinite loop on cyclic dependency

This patch
- uses stack instead of recursion
- checks for cyclomatic dependencies
