### PR TITLE
added sequelize-restful <0.3.1

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -137,6 +137,8 @@
 	},	
 	"htmlparser2": {
 		"vulnerabilities" : [ { "below" : "3.8.3", "info" : [ "https://github.com/fb55/htmlparser2/issues/105" ] } ]
-	}	
-
+	},
+	"sequelize-restful": {
+		"vulnerabilities" : [ { "below" : "0.3.1", "info" : [ "https://github.com/sequelize/sequelize-restful/issues/16" ] } ]
+	}
 }


### PR DESCRIPTION
Some requests might manage to crash an application by overwhelming the RegEx used for parsing the URL, e.g. `/dsssdsasdrg/ERG7ere/ERZEH7ersssshseth/SERZT7/rg/srg/RG7SG/sg/sssserg?length=`
