### PR TITLE
Use different exit code when vulnerabilities are found

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -133,7 +133,7 @@ events.on('scan-done', function() {
   if (config.outputformat === 'json') {
     (vulnsFound ? console.warn : console.log)(JSON.stringify(finalResults));
   }
-  process.exit(vulnsFound ? 1 : 0);
+  process.exit(vulnsFound ? 13 : 0);
 });
 
 process.on('uncaughtException', function (err) {


### PR DESCRIPTION
(This change was previously in a different pull request, but I needed to move it to a different branch)

Exit Code 1 is typically reserved by Node for use when a process throws an uncaught fatal exception. When invoking RetireJS in a scripted environment, it's useful to be able to distinguish between situations where the tool ran successfully but found vulnerabilities, and situations where the tool failed. Exit code 13 is the lowest exit code not currently reserved for other purposes: http://nodejs.org/api/process.html#process_exit_codes

To preserve backwards compatibility, a command line argument could be added (maybe something like --environment script), so that existing code that relies on an exit code of 1 wouldn't break, but others would have a way to distinguish between a successful run that finds vulnerabilities and a failed run.

Another option might be to have a command line argument for an output file, where the results could be written, that would be separate from stderr (console.warn or console.error).