### PR TITLE
Fix console.error process.exit flush issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 firefox/js/retire.js
 firefox/lib/retire.js
 *.xpi
+
+.idea

--- a/node/bin/retire
+++ b/node/bin/retire
@@ -132,7 +132,7 @@ events.on('js-scanned', function() {
 
 events.on('scan-done', function() {
   if (config.outputformat === 'json') {
-    (vulnsFound ? console.warn : console.log)("this line should always print\n" + JSON.stringify(finalResults));
+    (vulnsFound ? console.warn : console.log)(JSON.stringify(finalResults));
   }
     var exit = function() {
         process.exit(vulnsFound ? (config.exitwith || 13) : 0);

--- a/node/bin/retire
+++ b/node/bin/retire
@@ -132,9 +132,15 @@ events.on('js-scanned', function() {
 
 events.on('scan-done', function() {
   if (config.outputformat === 'json') {
-    (vulnsFound ? console.warn : console.log)(JSON.stringify(finalResults));
+    (vulnsFound ? console.warn : console.log)("this line should always print\n" + JSON.stringify(finalResults));
   }
-  process.exit(vulnsFound ? (config.exitwith || 13) : 0);
+    var exit = function() {
+        process.exit(vulnsFound ? (config.exitwith || 13) : 0);
+    }
+    var stream = (vulnsFound ? process.stderr : process.stdout);
+    if (! stream.write('', exit)) {
+        stream.on('drain', exit);
+    }
 });
 
 process.on('uncaughtException', function (err) {
@@ -158,4 +164,3 @@ if (config.node) {
 } else {
   events.emit('load-js-repo');
 }
-


### PR DESCRIPTION
This issue: 
https://github.com/joyent/node/issues/3584 
leads to incomplete output from RetireJS when it's run on Windows and its output is piped to a different process (this is often the case when invoking RetireJS programmatically).

We can resolve the problem by checking for unflushed output prior to exiting, and waiting for the "drain" event before calling process.exit.