### PR TITLE
Add support for output to file

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -45,6 +45,7 @@ program
   .option('--noderepo <path>', 'Local version of repo')
   .option('--proxy <url>', 'Proxy url (http://some.sever:8080)')
   .option('--outputformat <format>', 'Valid formats: text, json')
+  .option('--outputpath <path>', 'File to which output should be written')
   .option('--ignore <paths>', 'Comma delimited list of paths to ignore')
   .option('--ignorefile <path>', 'Custom .retireignore file, defaults to .retireignore')
   .option('--exitwith', 'Custom exit code (default: 13) when vulnerabilities are found')
@@ -52,7 +53,7 @@ program
 
 var config = _.extend({ path: '.' }, _.pick(program, [
   'package', 'node', 'js', 'jspath', 'verbose', 'nodepath', 'path', 'jsrepo', 'noderepo',
-  'dropexternal', 'nocache', 'proxy', 'ignore', 'ignorefile', 'outputformat', 'exitwith'
+  'dropexternal', 'nocache', 'proxy', 'ignore', 'ignorefile', 'outputformat', 'outputpath', 'exitwith'
 ]));
 
 if (!config.nocache) {
@@ -73,8 +74,6 @@ if(config.ignorefile) {
   ignored = _.map(lines, function(e) { return e[0] === '@' ? e.slice(1) : path.resolve(e); });
   config.ignore = config.ignore.concat(ignored);
 }
-
-
 
 events.on('load-js-repo', function() {
   (config.jsrepo
@@ -131,16 +130,28 @@ events.on('js-scanned', function() {
 });
 
 events.on('scan-done', function() {
+  var exit = function(exitCode) {
+    exitCode = exitCode || 0;
+    process.exit(vulnsFound ? (config.exitwith || 13) : exitCode);
+  };
   if (config.outputformat === 'json') {
-    (vulnsFound ? console.warn : console.log)(JSON.stringify(finalResults));
-  }
-    var exit = function() {
-        process.exit(vulnsFound ? (config.exitwith || 13) : 0);
-    }
-    var stream = (vulnsFound ? process.stderr : process.stdout);
-    if (! stream.write('', exit)) {
+    if (config.fileOutput) {
+      config.fileOutput.stream.on('drain', function() {
+        fs.close(config.fileOutput.fileDescriptor);
+        exit();
+      });
+      config.fileOutput.stream.write(JSON.stringify(finalResults));
+      config.fileOutput.stream.end();
+    } else {
+      (vulnsFound ? console.warn : console.log)(JSON.stringify(finalResults));
+      var stream = (vulnsFound ? process.stderr : process.stdout);
+      if (! stream.write('', exit)) {
         stream.on('drain', exit);
+      }
     }
+  }
+
+
 });
 
 process.on('uncaughtException', function (err) {
@@ -154,9 +165,26 @@ events.on('stop', function() {
   process.exit(1);
 });
 
+if (typeof config.outputpath === 'string') {
+  config.fileOutput = {
+    fileDescriptor: fs.openSync(config.outputpath, "w")
+  };
+  if (config.fileOutput.fileDescriptor < 0) {
+    console.error("Could not open " + config.outputpath + " for writing");
+    process.exit(9);
+  } else {
+    config.fileOutput.stream = fs.createWriteStream('', {fd: config.fileOutput.fileDescriptor});
+    config.writeToFile = function(message) {
+      config.fileOutput.stream.write(message);
+      config.fileOutput.stream.write('\n');
+    };
+    config.logger = config.writeToFile;
+  }
+}
+
 if (config.outputformat === 'json') {
-  config.logger = function() {};
-  config.warnlogger = function() {};
+  config.logger = function () {};
+  config.warnlogger = function () {};
 }
 
 if (config.node) {


### PR DESCRIPTION
You can use command line argument `--outputpath <file>` to route all the output to the file specified. Currently, it will overwrite the file if it exists and will fail without running any scan if the file can't be opened for writing.

One feature I didn't add, but we might want to consider is the ability to route vulnerabilities to one file and the rest of the output to another. Adding it wouldn't be all that difficult, but unless it's something people are actually going to use, I'll hold off on it for now.