### PR TITLE
Made version regex reluctant

### DIFF
--- a/node/lib/retire.js
+++ b/node/lib/retire.js
@@ -120,7 +120,7 @@ exports.check = function(component, version, repo) {
 };
 
 exports.replaceVersion = function(jsRepoJsonAsText) {
-	return jsRepoJsonAsText.replace(/§§version§§/g, '[0-9][0-9.a-z_\\\\-]+');
+	return jsRepoJsonAsText.replace(/§§version§§/g, '[0-9][0-9.a-z_\\\\-]+?');
 };
 
 exports.isVulnerable = function(results) {


### PR DESCRIPTION
The version regex which is generated is greedy, so in cases where the filename extractor contains an optional min (retire-example-(§§version§§)(.min)?\\.js), the ".min" becomes part of the matched version. Because of the way isAtOrAbove works, this hasn't been an issue in the past, but .min should not be part of the version number.