### PR TITLE
Update URLs for loading repository data from GitHub

### DIFF
--- a/firefox/lib/repo.js
+++ b/firefox/lib/repo.js
@@ -4,7 +4,7 @@ const retire = require("./retire");
 const promise = require("sdk/core/promise");
 const Request = require("sdk/request").Request;
 
-const REPO_URL = "https://raw.github.com/RetireJS/retire.js/master/repository/jsrepository.json";
+const REPO_URL = "https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json";
 
 let updatedAt = Date.now();
 let repository;

--- a/node/bin/retire
+++ b/node/bin/retire
@@ -78,7 +78,7 @@ if(config.ignorefile) {
 events.on('load-js-repo', function() {
   (config.jsrepo
     ? repo.loadrepositoryFromFile(config.jsrepo, config)
-    : repo.loadrepository('https://raw.github.com/RetireJS/retire.js/master/repository/jsrepository.json', config)
+    : repo.loadrepository('https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json', config)
   ).on('done', function(repo) {
       jsRepo = repo;
       events.emit('js-repo-loaded');
@@ -89,7 +89,7 @@ events.on('load-js-repo', function() {
 events.on('load-node-repo', function() {
   (config.noderepo
     ? repo.loadrepositoryFromFile(config.noderepo, config)
-    : repo.loadrepository('https://raw.github.com/RetireJS/retire.js/master/repository/npmrepository.json', config)
+    : repo.loadrepository('https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/npmrepository.json', config)
   ).on('done', function(repo) {
       nodeRepo = repo;
       events.emit('node-repo-loaded');


### PR DESCRIPTION
Swap from raw.github.com to raw.githubusercontent.com, as per https://developer.github.com/changes/2014-04-25-user-content-security/