### PR TITLE
Call exit() even if not using JSON output

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -150,8 +150,7 @@ events.on('scan-done', function() {
       }
     }
   }
-
-
+  exit();
 });
 
 process.on('uncaughtException', function (err) {


### PR DESCRIPTION
PR #91 made exit() only get called if the output format is JSON, which means if you're using this in the default text format, the exit code will always be 0, even if you have vulnerabilities.