### PR TITLE
Make jquery version extraction more specific

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -38,7 +38,7 @@
 				"info" : [ "http://bugs.jquery.com/ticket/11290" , "http://research.insecurelabs.org/jquery/test/" ]}
 		],
 		"extractors" : {
-			"func"    		: [ "jQuery.fn.jquery" ],
+			"func"    		: [ "/[0-9.]+/.test(jQuery.fn.jquery) ? jQuery.fn.jquery : undefined" ],
 			"uri"			: [ "/(§§version§§)/jquery(\\.min)?\\.js" ],
 			"filename"		: [ "jquery-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [


### PR DESCRIPTION
Change the jquery version extractor to more exactly recognize the format of jQuery versions.  The avoids recognizing jqLite as jQuery and marking the latest version of jqLite as a old vulnerable version of jQuery.

Fixes bug https://github.com/RetireJS/retire.js/issues/108