### PR TITLE
added jpm and firefox 38 support

### DIFF
--- a/firefox/package.json
+++ b/firefox/package.json
@@ -1,11 +1,12 @@
 {
   "name": "retirejs",
   "fullName": "Retire.js for Firefox",
-  "id": "jid1-WraQ74BxTHiaUw",
+  "id": "jid1-WraQ74BxTHiaUw@jetpack.org",
   "description": "Scanning website for vulernable js libraries. Icon by http://www.studiomx.eu/",
   "author": "Erlend Oftedal",
   "license": "Apache License, Version 2.0",
   "version": "0.1.2a1",
   "icon": "data/icons/add-on-icon.png",
-  "icon64": "data/icons/icon64.png"
+  "icon64": "data/icons/icon64.png",
+  "main": "lib/main.js"
 }

--- a/fx.sh
+++ b/fx.sh
@@ -13,11 +13,11 @@ target=$1
 release=false
 
 # ------------------------------------------------------------------------------
-# check if the cfx tool exist
+# check if the jpm tool exist
 # ------------------------------------------------------------------------------
 
-if ! type cfx > /dev/null; then
-  echo "Aborting cfx command not found"
+if ! type jpm > /dev/null; then
+  echo "Aborting jpm command not found"
   exit 1
 fi
 
@@ -84,7 +84,7 @@ done
 # ------------------------------------------------------------------------------
 
 function runTests {
-  cfx test
+  jpm test
 }
 
 # ------------------------------------------------------------------------------
@@ -94,9 +94,9 @@ function runTests {
 function runBrowser {
   if [ -z $FX_PROFILE_DIR ] 
   then
-    cfx run
+    jpm run
   else
-    cfx run -p $FX_PROFILE_DIR
+    jpm run -p $FX_PROFILE_DIR
   fi
 }
 
@@ -114,7 +114,7 @@ function build {
     else
       filename="${addonName}-${version}_${now}.xpi"
   fi
-  cfx xpi
+  jpm xpi
   mv $addonName.xpi $filename
   echo "Add-on built: $filename"
 }

--- a/fx.sh
+++ b/fx.sh
@@ -8,7 +8,7 @@ ADD_ON_DIR=./firefox
 NODE_RETIRE_JS_FILE=./node/lib/retire.js
 FX_RETIRE_JS_FILE=$ADD_ON_DIR/lib/retire.js
 FX_PROFILE_DIR=""
-
+FX_PATH=""
 target=$1
 release=false
 
@@ -71,6 +71,10 @@ do
       shift
       FX_PROFILE_DIR=$2
       ;;
+    -b | --binarypath )
+      shift
+      FX_PATH=$2
+      ;;
     -release ) 
       shift
       release=true
@@ -92,12 +96,21 @@ function runTests {
 # ------------------------------------------------------------------------------
 
 function runBrowser {
-  if [ -z $FX_PROFILE_DIR ] 
+  PROG_ARG=""
+  if ! [ -z $FX_PROFILE_DIR ] 
   then
-    jpm run
-  else
-    jpm run -p $FX_PROFILE_DIR
+    PROG_ARG="$PROG_ARG -p $FX_PROFILE_DIR "
   fi
+  #jpm run -p $FX_PROFILE_DIR 
+  if ! [ -z $FX_PATH ]
+  then
+    PROG_ARG="$PROG_ARG -b $FX_PATH"
+    echo $PROG_ARG
+  fi
+  echo $PROG_ARG
+  echo "jpm run @@$PROG_ARG@@"
+  jpm run $PROG_ARG
+  echo $PROG_ARG
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Since firefox 38 cfx is replaced with jpm and hence some customization is required in firefox extension too

https://blog.mozilla.org/addons/2015/02/26/jpm-replaces-cfx-for-firefox-38/

atleast the xpi is compiling and installing partially fixes #106 

but the plugin still needs to be tested for its usage.