### PR TITLE
Updated underscore dependency.

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/retire.js",
   "dependencies": {
-    "underscore"     : "1.7.x",
+    "underscore"     : "1.7.x - 1.8.x",
     "commander"	     : "2.5.x",
     "read-installed" : "3.1.x",
     "walkdir"        : "0.0.7",


### PR DESCRIPTION
I did a quick `ack '_[.(]'` to see if the upgrade would cause any
trouble, but seeing that only `extend`, `pick`, `map`, `flatten` and
`detect` are being used, it seemed save to allow `1.8.x` as well.

Useful link: http://underscorejs.org/#changelog