### PR TITLE
Added support for extracting version info of YUI v2.x branches.

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -345,7 +345,7 @@
 			}
 		],
 		"extractors" : {
-			"func"    		: [ "YUI.Version" ],
+			"func"    		: [ "YUI.Version", "YAHOO.VERSION" ],
 			"filename"		: [ "yui-(§§version§§)(.min)?\\.js"],
 			"filecontent"	: [ "/*\nYUI (§§version§§)", "/yui/license.(?:html|txt)\nversion: (§§version§§)"],
 			"hashes"		: {}


### PR DESCRIPTION
YUI v2.x branches use "YAHOO.VERSION" to expose version information, added support for this.