### PR TITLE
Added ability to download repos from internal URL

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -41,8 +41,8 @@ program
   .option('--jspath <path>', 'Folder to scan for javascript files')
   .option('--nodepath <path>', 'Folder to scan for node files')
   .option('--path <path>', 'Folder to scan for both')
-  .option('--jsrepo <path>', 'Local version of repo')
-  .option('--noderepo <path>', 'Local version of repo')
+  .option('--jsrepo <path|url>', 'Local or internal version of repo')
+  .option('--noderepo <path|url>', 'Local or internal version of repo')
   .option('--proxy <url>', 'Proxy url (http://some.sever:8080)')
   .option('--outputformat <format>', 'Valid formats: text, json')
   .option('--outputpath <path>', 'File to which output should be written')
@@ -77,7 +77,9 @@ if(config.ignorefile) {
 
 events.on('load-js-repo', function() {
   (config.jsrepo
-    ? repo.loadrepositoryFromFile(config.jsrepo, config)
+    ? (config.jsrepo.match(/^https?:\/\//)
+      ? repo.loadrepository(config.jsrepo, config)
+      : repo.loadrepositoryFromFile(config.jsrepo, config))
     : repo.loadrepository('https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json', config)
   ).on('done', function(repo) {
       jsRepo = repo;
@@ -88,7 +90,9 @@ events.on('load-js-repo', function() {
 
 events.on('load-node-repo', function() {
   (config.noderepo
-    ? repo.loadrepositoryFromFile(config.noderepo, config)
+    ? (config.noderepo.match(/^https?:\/\//)
+      ? repo.loadrepository(config.noderepo, config)
+      : repo.loadrepositoryFromFile(config.noderepo, config))
     : repo.loadrepository('https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/npmrepository.json', config)
   ).on('done', function(repo) {
       nodeRepo = repo;

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -376,6 +376,48 @@
 	},
 	"ember" : {
 		"vulnerabilities" : [
+			{ 
+				"atOrAbove" : "1.8.0",
+				"below" :"1.11.4",
+				"severity" : "medium",
+				"identifiers": {"CVE": "CVE-2015-7565"},
+				"info": [ "https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY" ]
+			},
+			{ 
+				"atOrAbove" : "1.12.0",
+				"below" :"1.12.2",
+				"severity" : "medium",
+				"identifiers": {"CVE": "CVE-2015-7565"},
+				"info": [ "https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY" ]
+			},
+			{ 
+				"atOrAbove" : "1.13.0",
+				"below" : "1.13.12",
+				"severity" : "medium",
+				"identifiers": {"CVE": "CVE-2015-7565"},
+				"info": [ "https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY" ]
+			},
+			{ 
+				"atOrAbove" : "2.0.0",
+				"below" : "2.0.3",
+				"severity" : "medium",
+				"identifiers": {"CVE": "CVE-2015-7565"},
+				"info": [ "https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY" ]
+			},
+			{ 
+				"atOrAbove" : "2.1.0",
+				"below" : "2.1.2",
+				"severity" : "medium",
+				"identifiers": {"CVE": "CVE-2015-7565" },
+				"info": [ "https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY" ]
+			},
+			{ 
+				"atOrAbove" : "2.2.0",
+				"below" : "2.2.1",
+				"severity" : "medium",
+				"identifiers": {"CVE": "CVE-2015-7565"},
+				"info": [ "https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY" ]
+			},
 			{
 				"below" : "1.5.0",
 				"severity": "medium",
@@ -799,6 +841,20 @@
 		}
 	},
 
+	"flowplayer" : {
+		"vulnerabilities" : [
+			{
+				"below" : "5.4.3",
+				"severity": "medium",
+				"identifiers": { "summary" : "XSS vulnerability in Flash fallback" },
+				"info" : [ "https://github.com/flowplayer/flowplayer/issues/381" ]
+			}
+		],
+		"extractors" : {
+			"uri"			    : [ "flowplayer-(§§version§§)(\\.min)?\\.js" ],
+			"filename"		: [ "flowplayer-(§§version§§)(\\.min)?\\.js" ]
+		}
+	},
 
 	"DWR" : {
 		"vulnerabilities" : [


### PR DESCRIPTION
This patch adds the ability to specify a different URL to download the jsrepository and npmrepository from for cases where the user might have an internal host where the repositories are cached.