### PR TITLE
is-my-json-valid is pointing to the wrong security advisory

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -748,7 +748,7 @@
 				"below" : "2.12.4",
 				"severity": "medium",
 				"identifiers": { "summary" : "Regex denial of service" },
-				"info" : [ "https://nodesecurity.io/advisories/49" ]
+				"info" : [ "https://nodesecurity.io/advisories/76" ]
 			}
 		]
 	},


### PR DESCRIPTION
The original incorrect reference was to a mapbox.js security issue.