### PR TITLE
Add missing atOrAbove condition to CVE-2013-4940.

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -346,6 +346,7 @@
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2013-4941/" ]
 			},
 			{
+				"atOrAbove" : "3.0.0",
 				"below" : "3.10.3",
 				"severity": "high",
 				"identifiers": {"CVE": [ "CVE-2013-4940" ] },


### PR DESCRIPTION
Link to details here: http://www.cvedetails.com/cve/CVE-2013-4940/
The issue didn't exist before 3.0.0 as the affected flash file io.swf didn't exist prior.

