### PR TITLE
Update index.html with link to grunt-retire

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ known vulnerabilities.</p>
 <h2>
 <a name="grunt-plugin" class="anchor" href="#grunt-plugin"><span class="octicon octicon-link"></span></a>Grunt plugin</h2>
 
-<p>Scans your grunt enabled app for use of vulnerable JavaScript libraries and/or node modules.</p>
+<p><a href="https://github.com/bekk/grunt-retire">grunt-retire</a> scans your grunt enabled app for use of vulnerable JavaScript libraries and/or node modules.</p>
 
 
 


### PR DESCRIPTION
Added link to grunt-retire making it easier to find.

Started linking all the different ways to use retirejs, but got unsure if we should link to all the different subdirectories in the retirejs repo etc. So opted to not linking the list, but just adding a link in the grunt-retire section.