### PR TITLE
Fix broken sourceclear links

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -760,7 +760,7 @@
 				"identifiers": {
 					"summary": "UI Redress Attack Through Improper Sanitization of SVG Elements"
 				},
-				"info" : [ "https://srcclr.com/security/ui-redress-attack-through-improper/javascript/s-2252" ]			
+				"info" : [ "https://www.sourceclear.com/registry/security/ui-redress-attack-through-improper-sanitization-svg-elements/javascript/sid-2252" ]			
 			},
 			{
 				"below" : "1.5.0-beta.2",
@@ -768,7 +768,7 @@
 				"identifiers": {
 					"summary": "Arbitrary Code Execution Through SVG Animation Functionality"
 				},
-				"info" : [ "https://srcclr.com/security/arbitrary-code-execution-through-svg/javascript/s-2253" ]
+				"info" : [ "https://www.sourceclear.com/registry/security/arbitrary-code-execution-through-svg-animation-functionality/javascript/sid-2253" ]
 			},
 			{
 				"atOrAbove" : "1.3.3",
@@ -779,7 +779,7 @@
 				},
 				"info" : [ 
 					"https://github.com/angular/angular.js/issues/14939",
-					"https://srcclr.com/security/arbitrary-code-execution-via-constructor-access/javascript/sid-2589/summary" 
+					"https://www.sourceclear.com/registry/security/arbitrary-code-execution-via-constructor-access/javascript/sid-2589" 
 				]
 			}
 


### PR DESCRIPTION
They decided to change their domain and URL structure without redirecting users of the old URL to the new one.