### PR TITLE
Handle vulnerability definitions without "below" property

### DIFF
--- a/node/lib/retire.js
+++ b/node/lib/retire.js
@@ -72,7 +72,7 @@ function check(results, repo) {
 		if (!isDefined(repo[result.component])) continue;
 		var vulns = repo[result.component].vulnerabilities;
 		for (var i in vulns) {
-			if (!isAtOrAbove(result.version, vulns[i].below)) {
+			if (!isDefined(vulns[i].below) || !isAtOrAbove(result.version, vulns[i].below)) {
 				if (isDefined(vulns[i].atOrAbove) && !isAtOrAbove(result.version, vulns[i].atOrAbove)) {
 					continue;
 				}


### PR DESCRIPTION
This is a fix to issue https://github.com/RetireJS/retire.js/issues/141