### PR TITLE
Define “below” version for “cli” (1.0.0)

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -1050,7 +1050,7 @@
 	"cli": {
 		"vulnerabilities" : [
 			{
-				"atOrAbove" : "0.0.0",
+				"below" : "1.0.0",
 				"severity": "low",
 				"identifiers": {"advisory": "Arbitrary File Write"},
 				"info" : [ "https://nodesecurity.io/advisories/95" ]


### PR DESCRIPTION
The vulnerability has been fixed in commit https://github.com/node-js-libs/cli/commit/fd6bc4d2a901aabe0bb6067fbcc14a4fe3faa8b9 and included in the release v1.0.0 of cli already