### PR TITLE
Check if cache file exists before removing it.

### DIFF
--- a/node/lib/repo.js
+++ b/node/lib/repo.js
@@ -50,7 +50,9 @@ function loadFromCache(url, cachedir, options) {
             log(options).info("Loading from cache: " + url);
             return loadJsonFromFile(path.resolve(cachedir, cache[url].file), options);
         } else {
-            fs.unlink(path.resolve(cachedir, cache[url].date + '.json'));
+	    if (fs.existsSync(path.resolve(cachedir, cache[url].date + '.json'))) {
+            	fs.unlink(path.resolve(cachedir, cache[url].date + '.json'));
+	    }	    
         }
     }
     var events = new emitter();


### PR DESCRIPTION
Check if the cache file exists, if not don't try to delete it since that will throw an error. 
It can be removed by some other process or exception.