### PR TITLE
Add check for DOMPurify < 0.8.6

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -891,6 +891,12 @@
 				"severity": "medium",
 				"identifiers": { },
 				"info" : [ "https://github.com/cure53/DOMPurify/releases/tag/0.6.1" ]
+			},
+			{
+				"below" : "0.8.6",
+				"severity": "medium",
+				"identifiers": { },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases/tag/0.8.6" ]
 			}
 		],
 		"extractors" : {


### PR DESCRIPTION
DOMPurify below 0.8.6 is vulnerable to a XSS vulnerability in Safari 10.1 and 10.2.

Ref https://github.com/cure53/DOMPurify/releases/tag/0.8.6

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>