### PR TITLE
Fix incorrect npm repository JSON attributes

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -314,7 +314,7 @@
 		"vulnerabilities" : [
 		  {
         "below": "16.1.1",
-        "atOrAfter": "15.0.0",
+        "atOrAbove": "15.0.0",
         "severity": "medium",
         "identifiers": {
           "summary": "hapi_denial-of-service-via-malformed-accept-encoding-header"
@@ -772,7 +772,7 @@
 			},
 			      {
         "below": "1.2.3",
-        "atOrAfter": "1.2.2",
+        "atOrAbove": "1.2.2",
         "severity": "medium",
         "identifiers": {
           "summary": "sanitize-html_cross-site-scripting"
@@ -783,7 +783,7 @@
       },
       {
         "below": "1.11.4",
-        "atOrAfter": "1.11.1",
+        "atOrAbove": "1.11.1",
         "severity": "medium",
         "identifiers": {
           "summary": "sanitize-html_cross-site-scripting"
@@ -1559,7 +1559,7 @@
     "vulnerabilities": [
       {
         "below": "0.50.0",
-        "atOrAfter": "0.44.0",
+        "atOrAbove": "0.44.0",
         "severity": "medium",
         "identifiers": {
           "summary": "shout_html-injection"
@@ -1643,8 +1643,7 @@
   "gomeplus-h5-proxy": {
     "vulnerabilities": [
       {
-        "below": "<0.0.0",
-        "atOrAfter": "<=99.999.99999",
+        "below": "99.999.99999",
         "severity": "high",
         "identifiers": {
           "summary": "gomeplus-h5-proxy_directory-traversal"
@@ -1807,7 +1806,7 @@
       },
       {
         "below": "1.9.0",
-        "atOrAfter": "1.7.1",
+        "atOrAbove": "1.7.1",
         "severity": "high",
         "identifiers": {
           "summary": "jquery_xss-via-improper-selector-detection"
@@ -1822,7 +1821,7 @@
     "vulnerabilities": [
       {
         "below": "2.68.0",
-        "atOrAfter": "2.2.6",
+        "atOrAbove": "2.2.6",
         "severity": "medium",
         "identifiers": {
           "summary": "request_remote-memory-exposure"
@@ -1865,7 +1864,7 @@
     "vulnerabilities": [
       {
         "below": "1.1.2",
-        "atOrAfter": "1.1.0",
+        "atOrAbove": "1.1.0",
         "severity": "low",
         "identifiers": {
           "summary": "decamelize_regular-expression-denial-of-service"
@@ -1880,7 +1879,7 @@
     "vulnerabilities": [
       {
         "below": "99.999.99999",
-        "atOrAfter": "0.5.0",
+        "atOrAbove": "0.5.0",
         "severity": "medium",
         "identifiers": {
           "summary": "morrisjs_morrisjs"
@@ -1895,7 +1894,7 @@
     "vulnerabilities": [
       {
         "below": "3.0.0",
-        "atOrAfter": "2.1.1",
+        "atOrAbove": "2.1.1",
         "severity": "high",
         "identifiers": {
           "summary": "uri-js_regular-expression-denial-of-service"
@@ -1910,7 +1909,7 @@
     "vulnerabilities": [
       {
         "below": "99.99.9999",
-        "atOrAfter": "0.1.0",
+        "atOrAbove": "0.1.0",
         "severity": "medium",
         "identifiers": {
           "summary": "summit_unsafe-eval"
@@ -1939,7 +1938,7 @@
     "vulnerabilities": [
       {
         "below": "4.1.0",
-        "atOrAfter": "2.0.0",
+        "atOrAbove": "2.0.0",
         "severity": "medium",
         "identifiers": {
           "summary": "restify_xss"
@@ -2013,7 +2012,7 @@
     "vulnerabilities": [
       {
         "below": "3.4.4",
-        "atOrAfter": "2.0.0",
+        "atOrAbove": "2.0.0",
         "severity": "medium",
         "identifiers": {
           "summary": "i18next_cross-site-scripting"
@@ -2132,7 +2131,7 @@
     "vulnerabilities": [
       {
         "below": "0.9.7",
-        "atOrAfter": "0.2.0",
+        "atOrAbove": "0.2.0",
         "severity": "high",
         "identifiers": {
           "summary": "fury-adapter-swagger_arbitrary-file-read"
@@ -4166,7 +4165,7 @@
     "vulnerabilities": [
       {
         "below": "1.7.2",
-        "atOrAfter": "1.7.0",
+        "atOrAbove": "1.7.0",
         "severity": "medium",
         "identifiers": {
           "summary": "serve-static_open-redirect"
@@ -4295,7 +4294,7 @@
     "vulnerabilities": [
       {
         "below": "4.5",
-        "atOrAfter": "4.0",
+        "atOrAbove": "4.0",
         "severity": "medium",
         "identifiers": {
           "summary": "express_no-charset-in-content-type-header"


### PR DESCRIPTION
This fixes a previous commit that had used "atOrAfter" in place of "atOrAbove" for several vulnerabilities.
It also corrects the vulnerability range for "gomeplus-h5-proxy".