### PR TITLE
Allow no dependencies key in package.json

### DIFF
--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -39,7 +39,7 @@ function getNodeDependencies(path, limit) {
 			var packages = JSON.parse(fs.readFileSync(path +'/package.json'));
 			filter = [];			
 
-			var filter = Object.keys(packages.dependencies);
+			var filter = packages.dependencies ? Object.keys(packages.dependencies) : [];
 			Object.keys(pkginfo.dependencies)
 				.filter(function(d) { return filter.indexOf(d) == -1; })
 				.forEach(function(d) { delete pkginfo.dependencies[d]; });


### PR DESCRIPTION
This fixes a runtime error (TypeError: Cannot convert undefined or null to object) when running retire on a project where there is no  dependencies key in the package.json.