### PR TITLE
fix 'exit with error' issue

### DIFF
--- a/node/lib/reporting.js
+++ b/node/lib/reporting.js
@@ -38,11 +38,7 @@ var writer = {
   out: console.log,
   err: function(x) { console.warn(colorwarn(x)); },
   close : function(callback) { 
-    process.stderr.on('drain', function() {
-      process.stderr.on('drain', function() {
-        callback();
-      });
-    });
+    callback();
   }
 };
 


### PR DESCRIPTION
Check ends with 0 exit code all time . It's because close method twice wait for process.stderr 'drain' event. But it isn't ever been emitted. And may be i'm not right, but I think It's not necessary to use 'drain' here. https://nodejs.org/api/stream.html#stream_event_drain Please, correct me if I'm wrong.