### PR TITLE
simpleserver port argument with python 2 and 3 support

### DIFF
--- a/simpleserver.py
+++ b/simpleserver.py
@@ -1,3 +1,17 @@
-#!/bin/bash
+#!/bin/env bash
+
+PYTHON_VERSION=$(python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))')
+
+if [ -z "$1" ]; then
+    PORT=8000
+else
+    PORT=$1
+fi
+
 cd repository
-python -m SimpleHTTPServer
+
+if [ ${PYTHON_VERSION} -eq 0 ]; then
+    python -m http.server $PORT
+else
+    python -m SimpleHTTPServer $PORT
+fi


### PR DESCRIPTION
Adds the ability with simple server to change the port as well support both python 2 and 3.

Simple but perhaps useful.

Enjoy! :smile: 