### PR TITLE
Feat/make output more informative

### DIFF
--- a/node/lib/reporters/console.js
+++ b/node/lib/reporters/console.js
@@ -8,15 +8,21 @@ function printResults(logger, finding, config) {
     var printed = {};
     finding.results.forEach(function(elm) {
       var key = elm.component + ' ' + elm.version;
-      logFunc(finding.file);
-      logFunc(' ' + String.fromCharCode(8627) + ' ' + key);
       if (printed[key]) return;
       if (retire.isVulnerable([elm])) {
         logFunc(key + ' has known vulnerabilities:' + printVulnerability(logger, elm, config));
+        if (elm.parent) {
+          printParent(logFunc, elm, config);
+        }
       }
       printed[key] = true;
     });
   }
+}
+
+function printParent(logFunc, comp, options) {
+  if ('parent' in comp) printParent(logFunc, comp.parent, options);
+  logFunc(new Array(comp.level).join(' ') + (comp.parent ? String.fromCharCode(8627) + ' ' : '') + comp.component + ' ' + comp.version);
 }
 
 function printVulnerability(logger, component, config) {

--- a/node/lib/reporting.js
+++ b/node/lib/reporting.js
@@ -38,11 +38,7 @@ var writer = {
   out: console.log,
   err: function(x) { console.warn(colorwarn(x)); },
   close : function(callback) { 
-    process.stderr.on('drain', function() {
-      process.stderr.on('drain', function() {
-        callback();
-      });
-    });
+    callback();
   }
 };
 

--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -30,7 +30,10 @@ function listdep(parent, dep, level, deps) {
 			dedup[id] = true;
 			var d = { 
 				file: "node_modules" + o.dep.dependencies[i].path.split("node_modules").slice(1).join("node_modules") + '/package.json',
-				module: { component: i, version: o.dep.dependencies[i].version }
+				component: i,
+				version: o.dep.dependencies[i].version,
+				parent: o.parent,
+				level: o.level,
 			};
 			deps.push(d);
 			stack.push({parent: d, dep: o.dep.dependencies[i], level: o.level + 1}); 

--- a/node/lib/scanner.js
+++ b/node/lib/scanner.js
@@ -82,7 +82,7 @@ function scanDependencies(dependencies, nodeRepo, options) {
     if (options.ignore && shouldIgnorePath([dependencies[i].component, toModulePath(dependencies[i])], options.ignore)) {
       continue;
     }
-    results = retire.scanNodeDependency(dependencies[i].module, nodeRepo, options);
+    results = retire.scanNodeDependency(dependencies[i], nodeRepo, options);
     emitResults({file: dependencies[i].file, results: results}, options);
   }
 }


### PR DESCRIPTION
**In retire.js 1.x the report had the following format:**

protobufjs 5.0.2 has known vulnerabilities:  severity: medium; summary: Denial of Service; https://hackerone.com/reports/319576
node-site-venom 1.0.2843
↳ firebase 4.8.1
 ↳ @firebase/firestore 0.2.2
  ↳ grpc 1.8.0
   ↳ protobufjs 5.0.2


**Now we have this:**

node_modules/protobufjs/package.json
 ↳ protobufjs 5.0.2
protobufjs 5.0.2 has known vulnerabilities: severity: medium; summary: Denial of Service; https://hackerone.com/reports/319576


I've created the pr with changes for console reporter to have the first variant in report. It would be cool to have the previous version of report format. Because it's more informative for usage.