### PR TITLE
Ensuring concurrently running instances of retire don't break

### DIFF
--- a/node/lib/repo.js
+++ b/node/lib/repo.js
@@ -49,8 +49,12 @@ function loadFromCache(url, cachedir, options) {
       options.log.info('Loading from cache: ' + url);
       return loadJsonFromFile(path.resolve(cachedir, cache[url].file), options);
     } else {
-      if (fs.existsSync(path.resolve(cachedir, cache[url].date + '.json'))) {
+      try {
         fs.unlinkSync(path.resolve(cachedir, cache[url].date + '.json'));
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
       }
     }
   }
@@ -66,7 +70,7 @@ function loadFromCache(url, cachedir, options) {
 
 exports.asbowerrepo = function(jsRepo) {
   var result = {};
-  Object.keys(jsRepo).map(function(k) { 
+  Object.keys(jsRepo).map(function(k) {
     (jsRepo[k].bowername || [k]).map(function(b) {
       result[b] = result[b] || { vulnerabilities: [] };
       result[b].vulnerabilities = result[b].vulnerabilities.concat(jsRepo[k].vulnerabilities);


### PR DESCRIPTION
When multiple instances of retire are run concurrently, in separate processes, `fs.existsSync` will sometimes return true but then `fs.unlinkSync` will result in an `ENOENT` "no such file or directory" error. Rather than check for the existence of the file, I'm just attempting to delete it and ignoring any `ENOENT` errors.

Closes #235