### PR TITLE
Macaddress module was patched in v0.2.9

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -5121,13 +5121,14 @@
   "macaddress": {
     "vulnerabilities": [
       {
-        "below": "99.999.99999",
+        "below": "0.2.9",
         "severity": "critical",
         "identifiers": {
           "summary": "Command Injection"
         },
         "info": [
-          "https://hackerone.com/reports/319467"
+          "https://hackerone.com/reports/319467",
+          "https://nodesecurity.io/advisories/654"
         ]
       }
     ]


### PR DESCRIPTION
The macaddress module vulnerability described on https://hackerone.com/reports/319467 was patched in v0.2.9: https://nodesecurity.io/advisories/654

I'm not sure whether in these cases the process is to remove the hackerone report and replace it by the nodesecurity link, or to have both in the Info package?

C:\temp\retire.js\repository (macaddress-patched -> origin)
λ node validate
Checking that jsrepository is valid json...
Validating regexes...
107 regexes validated.
Checking that npmrepository is valid json...
Looking for duplicate keys...
Success