### PR TITLE
Improve correlation with other scanners for prototypejs and moment

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -516,7 +516,7 @@
 		}
 	},
 	"prototypejs" : {
-		"bowername": [ "prototype.js", "prototypejs", "prototypejs-bower" ],
+		"bowername": [ "prototypejs", "prototype.js", "prototypejs-bower" ],
 		"vulnerabilities" : [
 			{
 				"atOrAbove" : "1.6.0",
@@ -1120,7 +1120,7 @@
 	},
 
 	"moment.js" : {
-		"bowername": [ "momentjs", "moment" ],
+		"bowername": [ "moment", "momentjs" ],
 		"vulnerabilities" : [
 			{
 				"below" : "2.11.2",


### PR DESCRIPTION
This PR is a small change to the order of bowernames for in the JS repository for prototypejs and moment.
Aim is to make sure the first bower name in the repository is the primary or most frequently used package name. This helps when correlation the results with other vulnerability scanners (e.g. OSSIndex).

See for moment.js: 
https://libraries.io/bower/moment vs https://libraries.io/bower/momentjs
("moment" is the primary package name)

and for prototype.js: https://libraries.io/bower/prototypejs vs https://libraries.io/bower/prototype.js
("prototypejs" is the primary package name)