### PR TITLE
Add lockfile option and fix yarn workspaces

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -36,6 +36,7 @@ Options:
 --ignorefile <path>     Custom .retireignore file, defaults to .retireignore
 --severity <level>      Specify the bug severity level from which the process fails. Allowed levels none, low, medium, high, critical. Default: none
 --exitwith <code>       Custom exit code (default: 13) when vulnerabilities are found
+--lockfile <type>       Use lockfile instead of package scan. Allowed types npm, yarn, yarn-workspace. Default: npm
 ````
 
 .retireignore 

--- a/node/README.md
+++ b/node/README.md
@@ -36,7 +36,7 @@ Options:
 --ignorefile <path>     Custom .retireignore file, defaults to .retireignore
 --severity <level>      Specify the bug severity level from which the process fails. Allowed levels none, low, medium, high, critical. Default: none
 --exitwith <code>       Custom exit code (default: 13) when vulnerabilities are found
---lockfile <type>       Use lockfile instead of package scan. Allowed types npm, yarn, yarn-workspace. Default: npm
+--lockfile <type>       Use lockfile instead of package scan. Allowed types npm, yarn, yarn-workspace
 ````
 
 .retireignore 

--- a/node/bin/retire
+++ b/node/bin/retire
@@ -64,12 +64,13 @@ program
   .option('--severity <level>', 'Specify the bug severity level from which the process fails. Allowed levels none, low, medium, high, critical. Default: none')
   .option('--exitwith <code>', 'Custom exit code (default: 13) when vulnerabilities are found')
   .option('--colors', 'Enable color output (console output only)')
+  .option('--lockfile <type>', 'Use lockfile instead of package scan. Allowed types npm, yarn, yarn-workspace. Default: npm')
   .parse(process.argv);
 
 var config = utils.extend({ path: '.' }, utils.pick(program, [
   'package', 'node', 'js', 'jspath', 'verbose', 'nodepath', 'path', 'jsrepo', 'noderepo',
   'dropexternal', 'nocache', 'proxy', 'ignore', 'ignorefile', 'outputformat', 'outputpath',
-  'severity', 'exitwith', 'colors', 'includemeta', 'cachedir'
+  'severity', 'exitwith', 'colors', 'includemeta', 'cachedir', 'lockfile'
 ]));
 
 if (!config.nocache && !config.cachedir) {
@@ -189,7 +190,7 @@ events.on('scan-js', function() {
 });
 
 events.on('scan-node', function() {
-  resolve.getNodeDependencies(config.nodepath || config.path, config.package).on('done', function(dependencies) {
+  resolve.getNodeDependencies(config.nodepath || config.path, config.package, config.lockfile).on('done', function(dependencies) {
     scanner.scanDependencies(dependencies, nodeRepo, config);
     events.emit('scan-done');
   }).on('error', function(err) {

--- a/node/bin/retire
+++ b/node/bin/retire
@@ -64,7 +64,7 @@ program
   .option('--severity <level>', 'Specify the bug severity level from which the process fails. Allowed levels none, low, medium, high, critical. Default: none')
   .option('--exitwith <code>', 'Custom exit code (default: 13) when vulnerabilities are found')
   .option('--colors', 'Enable color output (console output only)')
-  .option('--lockfile <type>', 'Use lockfile instead of package scan. Allowed types npm, yarn, yarn-workspace. Default: npm')
+  .option('--lockfile <type>', 'Use lockfile instead of package scan. Allowed types npm, yarn, yarn-workspace')
   .parse(process.argv);
 
 var config = utils.extend({ path: '.' }, utils.pick(program, [

--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -114,15 +114,17 @@ function fetchPackageLockDependencies(lockFileName, events) {
 function getNodeDependencies(path, limit, lockfile) {
 	var events = new emitter();
 
-	if (lockfile) {
-		if (lockfile === 'npm') {
-			fetchPackageLockDependencies(path + '/package-lock.json', events);
-		} else if (lockfile === 'yarn') {
+	if (lockfile !== undefined) {
+		if (lockfile === 'yarn') {
 			fetchYarnLockDependencies('./yarn.lock', events);
 		} else if (lockfile === 'yarn-workspace') {
 			var yarnWorkspaceRoot = findYarnWorkspaceRoot();
 			var lockFileName = yarnWorkspaceRoot + '/yarn.lock';
 			fetchYarnLockDependencies(lockFileName, events);
+		} else if (lockfile === 'npm') {
+			fetchPackageLockDependencies(path + '/package-lock.json', events);
+		} else {
+			events.emit('error', 'Invalid lockfile type ' + lockfile);
 		}
 	} else {
 		fetchChildDependencies(path, limit, events);

--- a/node/package.json
+++ b/node/package.json
@@ -12,8 +12,10 @@
   },
   "main": "./lib/retire.js",
   "dependencies": {
+    "@yarnpkg/lockfile": "^1.0.2",
     "colors": "^1.1.2",
     "commander": "2.5.x",
+    "find-yarn-workspace-root": "^1.2.0",
     "read-installed": "^4.0.3",
     "request": "~2.x.x",
     "walkdir": "0.0.7"


### PR DESCRIPTION
This closes #241 

Allow users to supply a lockfile instead of performing manual package scan