### PR TITLE
Add replace regex to match older versions of tinyMCE

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -516,7 +516,7 @@
 		}
 	},
 	"prototypejs" : {
-		"bowername": [ "prototype.js", "prototypejs", "prototypejs-bower" ],
+		"bowername": [ "prototypejs", "prototype.js", "prototypejs-bower" ],
 		"vulnerabilities" : [
 			{
 				"atOrAbove" : "1.6.0",
@@ -1120,7 +1120,7 @@
 	},
 
 	"moment.js" : {
-		"bowername": [ "momentjs", "moment" ],
+		"bowername": [ "moment", "momentjs" ],
 		"vulnerabilities" : [
 			{
 				"below" : "2.11.2",

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -422,9 +422,12 @@
 			}
 		],
 		"extractors" : {
-			"filecontent"	       : [ "// (§§version§§) \\([0-9\\-]+\\)[\n\r]+.{0,1200}l=.tinymce/geom/Rect." ],
-			"filecontentreplace" : [ "/tinyMCEPreInit.*majorVersion:.([0-9]+).,minorVersion:.([0-9.]+)./$1.$2/" ],
-			"func" 				       : [ "tinyMCE.majorVersion + '.'+ tinyMCE.minorVersion" ]
+			"filecontent"	     : [ "// (§§version§§) \\([0-9\\-]+\\)[\n\r]+.{0,1200}l=.tinymce/geom/Rect." ],
+			"filecontentreplace" : [ 	
+										"/tinyMCEPreInit.*majorVersion:.([0-9]+).,minorVersion:.([0-9.]+)./$1.$2/",
+										"/majorVersion:.([0-9]+).,minorVersion:.([0-9.]+).,.*tinyMCEPreInit/$1.$2/" 
+								   ],
+			"func" 				 : [ "tinyMCE.majorVersion + '.'+ tinyMCE.minorVersion" ]
 		}
 	},
 


### PR DESCRIPTION
The prior regex did not match versions 3.* to at least 4.3.*.
E.g. in 3.5.10 the marker `tinyMCEPreInit` comes after `majorVersion:"3",minorVersion:"5.10"`.
See [here](http://archive.tinymce.com/download/older.php) for older versions of tinyMCE.

