### PR TITLE
Updated ProtobufJS Versions

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -5014,6 +5014,17 @@
   "protobufjs": {
     "vulnerabilities": [
       {
+        "below": "5.0.3",
+        "severity": "medium",
+        "identifiers": {
+          "summary": "Denial of Service"
+        },
+        "info": [
+          "https://hackerone.com/reports/319576"
+        ]
+      },
+      {
+        "atOrAbove": "6.0.0",
         "below": "6.8.6",
         "severity": "medium",
         "identifiers": {


### PR DESCRIPTION
The authors of `protobufjs` back-ported the security fix from 6.8.6 into the 5.x branch at 5.0.3.  Updating the `npmrepository` file so it treats the 6.x and 5.x versions separately so the reporting comes out correctly.

This is related to issue https://github.com/RetireJS/retire.js/issues/275