### PR TITLE
repository update: base64url vulnerability is patched in later versions

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -5382,7 +5382,7 @@
   "base64url": {
     "vulnerabilities": [
       {
-        "below": "99.999.99999",
+        "below": "3.0.1",
         "severity": "high",
         "identifiers": {
           "summary": "Out-of-bounds Read"


### PR DESCRIPTION
The original issue created for the hackerone report and linked PR for the fix: https://github.com/brianloveswords/base64url/issues/24
Also see the npm security advisory has the updated version range: https://www.npmjs.com/advisories/658

Looking at the repo there isn't a tag for the 3.0.0 release so it's not guaranteed that the fix was actually  deployed until the 3.0.1 release so I set that as the minimum version.