### PR TITLE
Fixed wrong version number for npm module "merge-options"

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -5163,7 +5163,7 @@
   "merge-options": {
     "vulnerabilities": [
       {
-        "below": "1.0.2",
+        "below": "1.0.1",
         "severity": "low",
         "identifiers": {
           "summary": "Prototype pollution attack",


### PR DESCRIPTION
- CVE-2018-3752 was fixed in merge-options in 1.0.1, see:
-- https://github.com/schnittstabil/merge-options/issues/10
-- https://github.com/schnittstabil/merge-options/issues/8