### PR TITLE
HackerOne NodeJS Ecosystem Bug Bounty program - disclosed reports December 2018

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -5967,6 +5967,19 @@
         "info": [
           "https://hackerone.com/reports/384939"
         ]
+      },
+      {
+        "below": "1.0.7",
+        "severity": "high",
+        "identifiers": {
+          "summary": "Path Traversal",
+          "CVE": [
+            "CVE-2018-16479"
+          ]
+        },
+        "info": [
+          "https://hackerone.com/reports/411405"
+        ]
       }
     ]
   },
@@ -6195,6 +6208,20 @@
         },
         "info": [
           "https://hackerone.com/reports/430831"
+        ]
+      }
+    ]
+  },
+  "lutils-merge": {
+    "vulnerabilities": [
+      {
+        "below": "99.999.9999",
+        "severity": "medium",
+        "identifiers": {
+          "summary": "Prototype pollution"
+        },
+        "info": [
+          "https://hackerone.com/reports/439107"
         ]
       }
     ]


### PR DESCRIPTION
Hi,

Reports disclosed in December 2018.

```
$ ./validate
Checking that jsrepository is valid json...
Validating regexes...
119 regexes validated.
Checking that npmrepository is valid json...
Looking for duplicate keys...
Success
```

There are only two reports disclosed in December.
Looks like the program has lost its popularity, also does not accept new submissions more often now :/

I know people from NodeJS Security Working Group had issues with members wiling to triage, validate and handle reports on HackerOne, also there is npm Responsible Disclosure program running.

Anyway, I will keep posting PRs with disclosed reports as long as they will appear.

Regards,

bl4de
