### PR TITLE
Add more descriptive link for angularjs vulnerability

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -876,7 +876,7 @@
 				"identifiers": {
 					"summary": "DOS in $sanitize"
 				},
-				"info" : [ "https://github.com/angular/angular.js/blob/master/CHANGELOG.md" ]
+				"info" : [ "https://github.com/angular/angular.js/blob/master/CHANGELOG.md", "https://github.com/angular/angular.js/pull/15699" ]
 			},
 			{
 				"below" : "1.6.5",


### PR DESCRIPTION
The DOS in $Sanitize vulnerability for angularjs versions below 1.6.3 gives a link where it is pretty hard to find information on the exact vulnerability.

I found the specific issue and added a link so the next person with that needs it will have an easier time.