### PR TITLE
Added jquery vulnerability as per CVE-2019-11358

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -96,10 +96,16 @@
 				},
 				"severity": "medium",
 				"info" : [ "https://bugs.jquery.com/ticket/11974", "https://nvd.nist.gov/vuln/detail/CVE-2015-9251", "http://research.insecurelabs.org/jquery/test/" ]
+			},
+			{
+				"below" : "3.4.0",
+				"identifiers": {
+					"CVE" : [ "CVE-2019-11358" ],
+					"summary": "jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution"
+				},
+				"severity" : "low",
+				"info" : [ "https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/", "https://nvd.nist.gov/vuln/detail/CVE-2019-11358", "https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b" ]
 			}
-
-
-
 		],
 		"extractors" : {
 			"func"    		: [


### PR DESCRIPTION
This PR is to capture the recently fixed (in 3.4.0) vulnerability in JQuery, a prototype pollution one. it is considered a minor as it's quite difficult to exploit.