### PR TITLE
Fix json reporter exitWithError

### DIFF
--- a/node/lib/reporters/json.js
+++ b/node/lib/reporters/json.js
@@ -6,7 +6,7 @@ function configureJsonLogger(logger, writer, config) {
 	var finalResults = { version: retire.version, start: new Date(), data: [], messages: [], errors: [] };
 	logger.info = finalResults.messages.push;
 	logger.debug = config.verbose ? finalResults.messages.push : function() {};
-	logger.warn = logger.error = finalResults.errors.push;
+	logger.warn = logger.error = (message) => finalResults.errors.push(message);
 	logger.logVulnerableDependency = function(finding) {
 		vulnsFound = true;
 		finalResults.data.push(finding);


### PR DESCRIPTION
The issue I have is

```gherkin
When running a retire with json and output path
Then errors are not published to the final object, thus in the result
```

Errors and warnings reported with `exitWithError()` don't have results context, and storing data inside the logger object instead. Have a look at the code below, this is what happens

```
var obj = {}
var arr = []

obj.push = arr.push
obj.push(1)

console.log(arr)
console.log(obj)
```