### PR TITLE
Added popular bootstrap's uri extractor

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -1382,7 +1382,7 @@
 			}
 		],
 		"extractors" : {
-			"uri"			: [ "/(§§version§§)/bootstrap(\\.min)?\\.js" ],
+			"uri"			: [ "/(§§version§§)/bootstrap(\\.min)?\\.js", "/(§§version§§)/js/bootstrap(\\.min)?\\.js" ],
 			"filename"		: [ "bootstrap-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
 								"/\\*!? Bootstrap v(§§version§§)",


### PR DESCRIPTION
BootstrapCDN expose bootstrap js at '../bootstrap/_version_/**js**/bootstrap(.min).js' link, but existing uri extractor regex doesn't handle the **js** part. Note, that some old bootstrap libs don't have the version label in the content (e.g. http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js), so retire.js misses such findings.

This PR adds the uri regex that supports uri form exposed by CDNs.