### PR TITLE
Update jsrepository.json

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -980,7 +980,7 @@
 			"hashes"		: {}
 		}
 	},
-	"handlebars.js" : {
+	"handlebars" : {
 		"bowername": [ "handlebars", "handlebars.js" ],
 		"vulnerabilities" : [
 			{


### PR DESCRIPTION
This is more like a discussion PR. 

Rename package without `*.js` . Official name of this dependency seems to be `handlebars` https://www.npmjs.com/package/handlebars in npm. Shall we change `handlebars.js` -> `handlebars`

