### PR TITLE
Support insecure or self-signed SSL certs

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -38,12 +38,14 @@ Options:
   --severity <level>       Specify the bug severity level from which the process fails. Allowed levels none, low, medium, high, critical. Default: none
   --exitwith <code>        Custom exit code (default: 13) when vulnerabilities are found
   --colors                 Enable color output (console output only)
+  --insecure               Enable fetching remote jsrepo/noderepo files from hosts using an insecure or self-signed SSL (TLS) certificate
+  --cacert <path>          Use the specified certificate file to verify the peer used for fetching remote jsrepo/noderepo files
 ````
 
 The `depcheck` output format mimics the output of OWASP Dependency Check, but lacks some information compared to OWASP Dependency Check, because that information is not in the repo.
 The `cyclonedx` output format is based on based on the https://github.com/CycloneDX spec.
 
-.retireignore 
+.retireignore
 -------------
 ````
 @qs                                                             # ignore this module regardless of location
@@ -55,12 +57,12 @@ Due to a bug in ignore resolving, please upgrade to >= 1.1.3
 ------------------
 ````
 [
-	{ 
+	{
 		"component": "jquery",
 		"identifiers" : { "issue": "2432"},
 		"justification" : "We dont call external resources with jQuery"
 	},
-	{ 
+	{
 		"component": "jquery",
 		"version" : "2.1.4",
 		"justification" : "We dont call external resources with jQuery"

--- a/node/bin/retire
+++ b/node/bin/retire
@@ -64,12 +64,14 @@ program
   .option('--severity <level>', 'Specify the bug severity level from which the process fails. Allowed levels none, low, medium, high, critical. Default: none')
   .option('--exitwith <code>', 'Custom exit code (default: 13) when vulnerabilities are found')
   .option('--colors', 'Enable color output (console output only)')
+  .option('--insecure', 'Enable fetching remote jsrepo/noderepo files from hosts using an insecure or self-signed SSL (TLS) certificate')
+  .option('--cacert <path>', 'Use the specified certificate file to verify the peer used for fetching remote jsrepo/noderepo files')
   .parse(process.argv);
 
 var config = utils.extend({ path: '.' }, utils.pick(program, [
   'package', 'node', 'js', 'jspath', 'verbose', 'nodepath', 'path', 'jsrepo', 'noderepo',
   'dropexternal', 'nocache', 'proxy', 'ignore', 'ignorefile', 'outputformat', 'outputpath',
-  'severity', 'exitwith', 'colors', 'includemeta', 'cachedir'
+  'severity', 'exitwith', 'colors', 'includemeta', 'cachedir', 'insecure', 'cacert'
 ]));
 
 if (!config.nocache && !config.cachedir) {
@@ -100,6 +102,13 @@ if(!config.severity) {
   exitWithError('Error: Invalid severity level (' + config.severity + '). Valid levels are: ' + Object.keys(severityLevels).join(', '));
 }
 
+if(config.cacert) {
+  if (!fs.existsSync(config.cacert)) {
+    exitWithError('Error: Could not read cacert file: ' + config.cacert);
+  }
+  config.cacertbuf = fs.readFileSync(config.cacert);
+}
+
 if(config.ignorefile) {
   if (!fs.existsSync(config.ignorefile)) {
     exitWithError('Error: Could not read ignore file: ' + config.ignorefile);
@@ -123,7 +132,7 @@ if(config.ignorefile) {
 }
 config.ignore.paths = config.ignore.paths
   .map(p => p.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
-  .map(p => p.replace(/[*]{1,2}/g, (a) => a.length == 2 ? ".*" : "[^/]*")) 
+  .map(p => p.replace(/[*]{1,2}/g, (a) => a.length == 2 ? ".*" : "[^/]*"))
   .map(s => new RegExp(s)
 );
 
@@ -132,7 +141,7 @@ scanner.on('vulnerable-dependency-found', function(result) {
   var levels = result.results
     .map(function(r) {
       return r.vulnerabilities ? r.vulnerabilities.map(function(v) {
-        return severityLevels[v.severity || 'critical']; 
+        return severityLevels[v.severity || 'critical'];
       }) : []; });
   var severity = utils.flatten(levels).reduce(function(x,y) { return x > y ? x : y; });
   if(severity >= severityLevels[config.severity]) {
@@ -145,9 +154,9 @@ scanner.on('dependency-found', log.logDependency);
 
 
 events.on('load-js-repo', function() {
-  (config.jsrepo ? 
+  (config.jsrepo ?
     (config.jsrepo.match(/^https?:\/\//) ?
-      repo.loadrepository(config.jsrepo, config) 
+      repo.loadrepository(config.jsrepo, config)
       : repo.loadrepositoryFromFile(config.jsrepo, config))
     : repo.loadrepository('https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json', config)
   ).on('stop', forward(events, 'stop'))
@@ -159,7 +168,7 @@ events.on('load-js-repo', function() {
 
 
 events.on('load-node-repo', function() {
-  (config.noderepo ? 
+  (config.noderepo ?
     (config.noderepo.match(/^https?:\/\//) ?
       repo.loadrepository(config.noderepo, config)
       : repo.loadrepositoryFromFile(config.noderepo, config))

--- a/node/lib/repo.js
+++ b/node/lib/repo.js
@@ -19,6 +19,12 @@ function loadJson(url, options) {
   if (options.proxy) {
     reqOptions.agent = new HttpsProxyAgent(options.proxy);
   }
+  if (options.insecure) {
+    reqOptions.rejectUnauthorized = false;
+  }
+  if (options.cacertbuf) {
+    reqOptions.ca = [ options.cacertbuf ];
+  }
   var req = (url.startsWith("http:") ? http : https).request(reqOptions, function (res) {
     if (res.statusCode != 200) return events.emit('stop', 'Error downloading: ' + url + ": HTTP " + res.statusCode + " " + res.statusText);
     var data = [];


### PR DESCRIPTION
This MR adds two new options to the commandline scanner:

1. `--insecure` - Enable fetching remote jsrepo/noderepo files from hosts using an insecure or self-signed SSL (TLS) certificate
1. `--cacert <path>` - Use the specified certificate file to verify the peer used for fetching remote jsrepo/noderepo files
