### PR TITLE
Removed entry for jquery-ui-autocomplete

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -282,20 +282,6 @@
 			"hashes"		: {}
 		}
 	},
-	"jquery-ui-autocomplete" : {
-		"bowername": [ "jquery-ui", "jquery.ui" ],
-		"vulnerabilities" : [ ],
-		"extractors" : {
-			"func"    		: [ "jQuery.ui.autocomplete.version" ],
-			"filecontent"	: [
-				"/\\*!? jQuery UI - v(§§version§§)(.*\n){1,3}.*jquery\\.ui\\.autocomplete\\.js",
-				"/\\*!?[\n *]+jQuery UI (§§version§§)(.*\n)*.*\\.ui\\.autocomplete",
-				"/\\*!?[\n *]+jQuery UI Autocomplete (§§version§§)",
-				"/\\*!? jQuery UI - v(§§version§§)(.*\n){1,3}\\* Includes: .* autocomplete\\.js"
-			],
-			"hashes"		: {}
-		}
-	},
 	"jquery-ui-tooltip" : {
 		"bowername": [ "jquery-ui", "jquery.ui" ],
 		"vulnerabilities" : [


### PR DESCRIPTION
This closes https://github.com/RetireJS/retire.js/issues/334

After this commit, Retire no longer returns a false positive (library detected without vulnerability mentioned).
```sh
[...]
 ↳ jquery-ui-autocomplete 1.9.2
jquery-ui-1.9.2.custom.js
[...]
```