### PR TITLE
Fixed incorrect tinyMCE vuln version

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -489,7 +489,7 @@
 				"info" : [ "https://www.tiny.cloud/docs/release-notes/release-notes516/" ]
 			},
 			{
-				"below" : "5.5.2",
+				"below" : "5.2.2",
 				"severity" : "low",
 				"identifiers" : { 
 					"summary" : "media embed content not processing safely in some cases."


### PR DESCRIPTION
One of the tinyMCE vulnerabilities added with 1b86c859bcd7723fc99ba64d782d3434434c6bcc matches an incorrect version. The correct version should be `5.2.2`, as linked in the info of that vulnerability.