### PR TITLE
Additional Bootstrap's filecontent extractor

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -1545,7 +1545,8 @@
 			"filecontent"	: [
 								"/\\*!? Bootstrap v(§§version§§)",
 								"\\* Bootstrap v(§§version§§)",
-								"/\\*! Bootstrap v(§§version§§)"
+								"/\\*! Bootstrap v(§§version§§)",
+								"this\\.close\\)};.\\.VERSION=\"(§§version§§)\"(?:,.\\.TRANSITION_DURATION=150)?,.\\.prototype\\.close"
 			],
 			"hashes"		: {}
 		}


### PR DESCRIPTION
I have encountered the case where the bootstrap.min.js was bundled with some other libs with comments removed (so the version couldn't be grabbed from there). But looking inside some 3.x.x versions of bootstrap's .min.js versions occurrences can be found:
```
d=function(b){a(b).on("click",c,this.close)};d.VERSION="3.2.0",d.prototype.close=function(b){function c()
d=function(b){a(b).on("click",c,this.close)};d.VERSION="3.3.0",d.TRANSITION_DURATION=150,d.prototype.close=function(b)
a=function(t){s(t).on("click",e,this.close)};a.VERSION="3.4.0",a.TRANSITION_DURATION=150,a.prototype.close=function(t)
d=function(b){a(b).on("click",c,this.close)};d.VERSION="3.3.7",d.TRANSITION_DURATION=150,d.prototype.close=function(b)
```
I'm proposing an additional, contextual filecontent extractor that covers these cases:
```
"this\\.close\\)};.\\.VERSION=\"(§§version§§)\"(?:,.\\.TRANSITION_DURATION=150)?,.\\.prototype\\.close"
``` 
I hope the context info is "wide" enough to avoid false positives (same patterns in other js libs)


