### PR TITLE
Log to console when verbose and exiting with error

### DIFF
--- a/node/bin/retire
+++ b/node/bin/retire
@@ -91,6 +91,7 @@ log.info("retire.js v" + retire.version);
 
 function exitWithError(msg) {
   log.error(config.colorwarn(msg));
+  if (config.verbose) log.consoleError(config.colorwarn(msg));
   process.exitCode = 1;
   log.close();
 }

--- a/node/lib/reporters/console.js
+++ b/node/lib/reporters/console.js
@@ -40,4 +40,5 @@ function printVulnerability(logger, component, config) {
 exports.configure = function(logger, writer, config, hash) {
     logger.logDependency = function(finding) { if (config.verbose) printResults(logger, finding, config); };
     logger.logVulnerableDependency = function(component) { printResults(logger, component, config); };
+    logger.consoleError = function() { };
 };

--- a/node/lib/reporters/json.js
+++ b/node/lib/reporters/json.js
@@ -25,6 +25,11 @@ function configureJsonLogger(logger, writer, config) {
 		write(JSON.stringify(res));
 		writer.close(callback); 
 	};
+	var consoleError = logger.consoleError;
+	logger.consoleError = function(msg) {
+		if (config.outputformat !== "jsonsimple") return;
+		consoleError(msg);
+	}
 }
 
 exports.configure = configureJsonLogger;

--- a/node/lib/reporting.js
+++ b/node/lib/reporting.js
@@ -84,6 +84,7 @@ exports.open = function(config) {
     console.warn("Invalid outputformat: " + format);
     process.exit(1);
   }
+  logger.consoleError = console.error;
   loggers[format].configure(logger, writer, config, hash);
 
   if (typeof config.outputpath === 'string') { 


### PR DESCRIPTION
This MR fixes an issue with error logging disappearing when `outputformat` is set to `jsonsimple`, `depcheck`, or `cyclonedx`. It's important to see why `retire` failed (especially important when running within tooling). Error logging disappears in these formats when [exitWithError](https://github.com/RetireJS/retire.js/blob/master/node/bin/retire#L92) is called.

This MR doesn't change how errors are output in the `json` and `console` formats. Console logging only happens with the `-v` option.

Here's an example of `console` `outputformat` when error is encountered (prints certificate error correctly):
```
retire -v --outputformat console --noderepo https://expired.badssl.com/
retire.js v2.2.3
Loading from cache: https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json
Reading /var/folders/82/0ws2wbfn42x86n7f65ykw8gw0000gn/T/.retire-cache/1603480308144.json ...
Downloading https://expired.badssl.com/ ...
Error downloading: https://expired.badssl.com/: Error: certificate has expired
```

Here's an example of `jsonsimple` `outputformat` when error is encountered:
```
retire -v --outputformat jsonsimple --noderepo https://expired.badssl.com/ 
[]
```

Here's the same output after this MR:
```
retire -v --outputformat jsonsimple --noderepo https://expired.badssl.com 
Error downloading: https://expired.badssl.com/: Error: certificate has expired
[]
```