### PR TITLE
Symlink with non-existent file caused uncaught exception

### DIFF
--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -84,6 +84,8 @@ function scanJsFiles(path) {
 			if (fs.lstatSync(file).isFile()) {
 				onFile(link);
 			}
+		} else {
+			console.log('Could not follow symlink: ' + link);
 		}
 	});
 	return finder;

--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -78,10 +78,12 @@ function scanJsFiles(path) {
 		}
 	}
 	finder.on('file', onFile);
-	finder.on('link', function(link) {
-		var file = fs.realpathSync(link);
-		if (fs.lstatSync(file).isFile()) {
-			onFile(link);
+	finder.on('link', function(link) {		
+		if (fs.existsSync(link)) {
+			var file = fs.realpathSync(link);
+			if (fs.lstatSync(file).isFile()) {
+				onFile(link);
+			}
 		}
 	});
 	return finder;


### PR DESCRIPTION
This checks that the underlying file exists before trying to resolve the real path.
Fixes #342