### PR TITLE
Move chrome logging from warn to log to squash plugin errors in the chrome extension manager page

### DIFF
--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -24,7 +24,7 @@ function download(url) {
 			if (xhr.status == 200) {
 				events.emit('success', xhr.responseText);
 			} else {
-				console.warn("Got " + xhr.status + " when trying to download " + url);
+				console.log("Got " + xhr.status + " when trying to download " + url);
 			}
 		}
 	};
@@ -116,7 +116,7 @@ function stringifyResults(results) {
 events.on('result-ready', function(details, results) {
 	var vulnerable = retire.isVulnerable(results);
 	if (vulnerable) {
-		console.warn(details.url, stringifyResults(results));
+		console.log(details.url, stringifyResults(results));
 		chrome.browserAction.setBadgeText({text : "!", tabId : details.tabId });
 	}
 	if (!vulnerable) console.log(details.url, stringifyResults(results));

--- a/chrome/js/content.js
+++ b/chrome/js/content.js
@@ -16,7 +16,7 @@
 					out.push(r.component + " " + r.version + " - Info: " +
 						r.vulnerabilities.map(function(i) { return i.info }).flatten().join(" "));
 				})
-				console.log("Loaded script with known vulnerabilities: " + result.url + "\n - " + out.join("\n - "));
+				console.warn("Loaded script with known vulnerabilities: " + result.url + "\n - " + out.join("\n - "));
 			}
 		} else if (request.getDetected) {
 			sendResponse(totalResults);

--- a/chrome/js/content.js
+++ b/chrome/js/content.js
@@ -16,7 +16,7 @@
 					out.push(r.component + " " + r.version + " - Info: " +
 						r.vulnerabilities.map(function(i) { return i.info }).flatten().join(" "));
 				})
-				console.warn("Loaded script with known vulnerabilities: " + result.url + "\n - " + out.join("\n - "));
+				console.log("Loaded script with known vulnerabilities: " + result.url + "\n - " + out.join("\n - "));
 			}
 		} else if (request.getDetected) {
 			sendResponse(totalResults);


### PR DESCRIPTION
trying to squash chrome error on extension page addressing https://github.com/RetireJS/retire.js/issues/350