### PR TITLE
Fix DoS-prone extractors for prettyPhoto and jPlayer

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -340,7 +340,7 @@
 		"extractors" : {
 			"func"    		: [ "jQuery.prettyPhoto.version" ],
 			"filecontent"	: [
-				"/\\*(?:.*[\n\r]+){1,3}.*Class: prettyPhoto(?:.*[\n\r]+){1,3}.*Version: (§§version§§)",
+				"/\\*[\r\n -]+Class: prettyPhoto(?:.*\n){1,3}[ ]*Version: (§§version§§)",
 				"\\.prettyPhoto[ ]?=[ ]?\\{version:[ ]?(?:'|\")(§§version§§)(?:'|\")\\}"
 			],
 			"hashes"		: {}
@@ -382,7 +382,8 @@
 		"extractors" : {
 			"func"    		: [ "new jQuery.jPlayer().version.script" ],
 			"filecontent"	: [
-				"/\\*(?:.*[\n\r]+){1,3}.*jPlayer Plugin for jQuery(?:.*[\n\r]+){1,10}.*Version: (§§version§§)"
+				"/\\*!?[\n *]+jPlayer Plugin for jQuery (?:.*\n){1,10}[ *]+Version: (§§version§§)",
+				"/\\*!? jPlayer (§§version§§) for jQuery"
 			],
 			"hashes"		: {}
 		}


### PR DESCRIPTION
In some cases `prettyPhoto` and `jPlayer` RegExp extractors lead to denial of service - node's process just stops responding.

Example:

```js
/**
 * @return {string}
 */
function generateTestStr() {
    let size = 20e6;
    let bodyStr = '';
    while (bodyStr.length < size) {
        bodyStr += '"/* dksjfsdkjf sdsd sd sd  */ abc",'
    }

    let str = [
        '/*! For license information please see LICENSE.txt */',
        bodyStr,
        '//# sourceMappingURL=vendors.js'
    ].join('\n');

    return str;
}

async function run() {
    // note: `§§version§§` -> `[0-9][0-9.a-z_\-]+`
    const rxCases = [
        // new expressions - fast execution
        /\/\*[\r\n -]+Class: prettyPhoto(?:.*\n){1,3}[ ]*Version: ([0-9][0-9.a-z_\-]+)/,
        /\/\*!?[\n *]+jPlayer Plugin for jQuery (?:.*\n){1,10}[ *]+Version: ([0-9][0-9.a-z_\-]+)/,

        // old expressions - DoS
        /\/\*(?:.*[\n\r]+){1,3}.*Class: prettyPhoto(?:.*[\n\r]+){1,3}.*Version: ([0-9][0-9.a-z_\-]+)/,
        /\/\*(?:.*[\n\r]+){1,3}.*jPlayer Plugin for jQuery(?:.*[\n\r]+){1,10}.*Version: ([0-9][0-9.a-z_\-]+)/,
    ];

    let str = generateTestStr();

    for (let rxCase of rxCases) {
        console.log(rxCase.toString());
        console.time('regex-test');
        rxCase.test(str);
        console.timeEnd('regex-test');
    }
}

run()
    .then(() => console.log('Done'))
    .catch(console.error);
```

The updated extractors can be verified with the following code:

<details><summary>Expand</summary>
<p>

```js
const retire = require('./node/lib/retire');
const fs = require('fs');

const repoData = fs.readFileSync('./repository/jsrepository.json', 'utf-8')
const repo = JSON.parse(retire.replaceVersion(repoData));

/**
 * @param {string} url 
 */
async function getContent(url) {
    return new Promise((resolve, reject) => {
        let http = (url.startsWith('https:') ? require('https') : require('http'));
        http.get(url, res => {
            res.setEncoding('utf-8');
            let ret = '';
            res.on("data", chunk => {
                ret += chunk;
            });
            res.on('end', () => {
                resolve(ret);
            })
            res.on('error', reject);
        }).on('error', reject);
    })
}

async function run(){
    const libUrls = [
        'https://cdnjs.cloudflare.com/ajax/libs/prettyPhoto/3.1.6/js/jquery.prettyPhoto.js',
        'https://cdn.jsdelivr.net/npm/jplayer@2.9.2/dist/jplayer/jquery.jplayer.js',
        'https://cdn.jsdelivr.net/npm/jplayer@2.9.2/dist/jplayer/jquery.jplayer.min.js',
    ]
    for (let url of libUrls) {
        console.log(url);
        let content = await getContent(url);
        let ret = retire.scanFileContent(content, repo, null);
        console.log(' - ', ret);
    }
}

run()
    .then(() => console.log('Done'))
    .catch(console.error);
```

</p>
</details>
