### PR TITLE
Fixing invalid json

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -1139,7 +1139,7 @@
 				"below" : "2.15.2",
 				"severity": "medium",
 				"identifiers": { 
-					"summary" : "Regular Expression Denial of Service (ReDoS)",
+					"summary" : "Regular Expression Denial of Service (ReDoS)"
 				},
 				"info" : [ 
 					"https://security.snyk.io/vuln/npm:moment:20161019"


### PR DESCRIPTION
remove unnecessary trailing comma

This was merged in this pr https://github.com/RetireJS/retire.js/pull/366

The extra trailing comma causes the follow stack trace.
```
Running "exec:retirejs" (exec) task
$ retire --jspath target/js --package
retire.js v2.2.1
Downloading https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json ...
Downloading https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/npmrepository.json ...
>> Exception caught:  [Arguments] {
>>   '0': SyntaxError: Unexpected token } in JSON at position 32132
>>       at JSON.parse (<anonymous>)
>>       at IncomingMessage.<anonymous> (/home/travis/build/okta/okta-signin-widget/node_modules/retire/lib/repo.js:35:34)
>>       at IncomingMessage.emit (events.js:326:22)
>>       at endReadableNT (_stream_readable.js:1241:12)
>>       at processTicksAndRejections (internal/process/task_queues.js:84:21),
>>   '1': 'uncaughtException'
>> }
>> SyntaxError: Unexpected token } in JSON at position 32132
>>     at JSON.parse (<anonymous>)
>>     at IncomingMessage.<anonymous> (/home/travis/build/okta/okta-signin-widget/node_modules/retire/lib/repo.js:35:34)
>>     at IncomingMessage.emit (events.js:326:22)
>>     at endReadableNT (_stream_readable.js:1241:12)
>>     at processTicksAndRejections (internal/process/task_queues.js:84:21)
>> error Command failed with exit code 1.
```