### PR TITLE
Remove comma to fix parsing of npmrepository.json

### DIFF
--- a/repository/npmrepository.json
+++ b/repository/npmrepository.json
@@ -1139,7 +1139,7 @@
 				"below" : "2.15.2",
 				"severity": "medium",
 				"identifiers": { 
-					"summary" : "Regular Expression Denial of Service (ReDoS)",
+					"summary" : "Regular Expression Denial of Service (ReDoS)"
 				},
 				"info" : [ 
 					"https://security.snyk.io/vuln/npm:moment:20161019"


### PR DESCRIPTION
The extra comma at the end of a single line json block creates an invalid json file structure. This will help in fixing the parsing error.