### PR TITLE
JSON repo fix

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -1531,7 +1531,7 @@
 				"severity": "low",
 				"identifiers": { 
 					"summary" : "Regular Expression Denial of Service (ReDoS)",
-					"CVE" : "CVE-2017-18214" 
+					"CVE" : [ "CVE-2017-18214" ] 
 				},
 				"info" : [ 
 					"https://security.snyk.io/vuln/npm:moment:20170905",


### PR DESCRIPTION
Keep CVE entries consistent with use of Array data type.

This is a quick fix, it seems setting up a job to validate against a schema might be a good move.
Example: https://github.com/OWASP/www-community/blob/master/.github/workflows/validate-tools-json.yml