### PR TITLE
Update jsrepository.json

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -1722,6 +1722,28 @@
 			]
 		}
 	},
+	"Underscore.js" : {
+		"bowername": [ "Underscore", "underscore" ],
+		"vulnerabilities" : [
+			{
+				"below" : "1.12.1",
+				"atOrAbove" : "1.3.2",
+				"severity": "High",
+				"identifiers": { "summary":" vulnerable to Arbitrary Code Injection via the template function",
+			        "CVE" : [ "CVE-2021-23358" ] 
+			},
+				"info" : [ "https://nvd.nist.gov/vuln/detail/CVE-2021-23358"
+				 ] 	 
+			}		
+		],
+		"extractors" : {
+			"uri" 			: [ "/underscore\\.js/(§§version§§)/underscore(-min)?\\.js" ],
+			"func"			: [ "underscore.version" ],
+			"filecontent"	: [ 
+				"//     Underscore.js (§§version§§)"	
+			]
+		}
+	},
 
 	"bootstrap": {
 		"vulnerabilities" : [


### PR DESCRIPTION
CVE-2021-23358
The package underscore from 1.13.0-0 and before 1.13.0-2, from 1.3.2 and before 1.12.1 are vulnerable to Arbitrary Code Injection via the template function, particularly when a variable property is passed as an argument as it is not sanitized.