### PR TITLE
Changed node/lib/retire.d.ts to be copied

### DIFF
--- a/node/lib/retire.d.ts
+++ b/node/lib/retire.d.ts
@@ -1,1 +1,15 @@
-../src/retire.d.ts
+import { Repository, Component, Hasher } from './types';
+
+export declare function check(component: string, version: string, repo: Repository): Component[];
+
+export declare function replaceVersion(jsRepoJsonAsText: string): string;
+
+export declare function isVulnerable(results: Component[]): boolean;
+
+export declare function scanUri(uri: string, repo: Repository): Component[];
+
+export declare function scanFileName(fileName: string, repo: Repository): Component[];
+
+export declare function scanFileContent(content: string, repo: Repository, hasher: Hasher): Component[];
+
+export declare const version: string;

--- a/node/package.json
+++ b/node/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "./test",
-    "build": "tsc && chmod ugo+x lib/cli.js",
+    "build": "tsc && chmod ugo+x lib/cli.js && cp src/retire.d.ts lib/retire.d.ts",
     "watch": "tsc --watch ",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts --fix --ignore-path ../.gitignore",


### PR DESCRIPTION
For issue #416 - this seems to work to solve my issue, based on local testing when I used `npm link` to try it in my project. Not sure if it broke anything else or if the historical reason for this being symlinked will reveal itself.