### PR TITLE
Update next.js vuln: added required 'info' attribute

### DIFF
--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -4041,7 +4041,10 @@
           "summary": "Next.js missing cache-control header may lead to CDN caching empty reply",
           "CVE": ["CVE-2023-46298"],
           "githubID": "GHSA-c59h-r6p8-q9wc"
-        }
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-c59h-r6p8-q9wc"
+        ]
       },
       {
         "atOrAbove": "10.0.0",


### PR DESCRIPTION
Commmit 0a61d8bbb7483e972c4bb07f4cdd3e0963f452d8 ("Update next.js vuln") creates a new vulnerability entry where the "info" field is missing. This is causing downstream issues as such field is requested by some libraries using the feeed. This commit add the missing field with the correct value. 