### PR TITLE
Extend AngularJS filecontent regex to match contents of 1.8.0 AngularJS

### DIFF
--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -2293,7 +2293,7 @@
       "uri": ["/(§§version§§)/angular(\\.min)?\\.js"],
       "filename": ["angular(?:js)?-(§§version§§)(.min)?\\.js"],
       "filecontent": [
-        "/\\*[ \n]+(?:@license )?AngularJS v(§§version§§)",
+        "/[\\* \n]+(?:@license )?AngularJS v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {}

--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -2293,7 +2293,7 @@
       "uri": ["/(§§version§§)/angular(\\.min)?\\.js"],
       "filename": ["angular(?:js)?-(§§version§§)(.min)?\\.js"],
       "filecontent": [
-        "/\\*[ \n]+AngularJS v(§§version§§)",
+        "/\\*[ \n]+(?:@license )?AngularJS v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {}

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -3143,7 +3143,7 @@
         "angular(?:js)?-(§§version§§)(.min)?\\.js"
       ],
       "filecontent": [
-        "/\\*[ \n]+AngularJS v(§§version§§)",
+        "/\\*[ \n]+(?:@license )?AngularJS v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {}

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -3143,7 +3143,7 @@
         "angular(?:js)?-(§§version§§)(.min)?\\.js"
       ],
       "filecontent": [
-        "/\\*[ \n]+(?:@license )?AngularJS v(§§version§§)",
+        "/[\\* \n]+(?:@license )?AngularJS v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {}

--- a/repository/testcases.json
+++ b/repository/testcases.json
@@ -422,7 +422,7 @@
   },
   "angularjs": {
     "https://code.angularjs.org/§§version§§/angular§§subversion§§.js": {
-      "versions": ["1.5.0", "1.6.0", "1.7.0","1.8.0", "1.8.1", "1.8.2"],
+      "versions": ["1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.8.1", "1.8.2"],
       "subversions": ["", ".min"]
     }
   }

--- a/repository/testcases.json
+++ b/repository/testcases.json
@@ -419,5 +419,11 @@
       "versions": ["3.0", "2.1"],
       "contentOnly": true
     }
+  },
+  "angularjs": {
+    "https://code.angularjs.org/§§version§§/angular§§subversion§§.js": {
+      "versions": ["1.5.0", "1.6.0", "1.7.0","1.8.0", "1.8.1", "1.8.2"],
+      "subversions": ["", ".min"]
+    }
   }
 }


### PR DESCRIPTION
retire.js is not currently recognising AngularJS 1.8.0 and potentially other versions. 

The first filecontent regular expression is as follows: `/\*[ \n]+AngularJS v(§§version§§)`

This matches https://code.angularjs.org/1.8.0/angular.min.js because the comment at the top of the file is

```
/*
 AngularJS v1.8.0
 (c) 2010-2020 Google, Inc. http://angularjs.org
 License: MIT
*/
```

However, https://code.angularjs.org/1.8.0/angular.js has a header of

```
/**
 * @license AngularJS v1.8.0
 * (c) 2010-2020 Google, Inc. http://angularjs.org
 * License: MIT
 */
```

Which does not match against the current implementation of the regex. This PR adds an optional non-capturing group of "@license " as a prefix to cover this case.