### PR TITLE
Fixes #440 - Reduce chance of false positives for pdf.js

### DIFF
--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -5993,7 +5993,6 @@
     "extractors": {
       "uri": ["/pdf\\.js/(§§version§§)/", "/pdfjs-dist@(§§version§§)/"],
       "filecontent": [
-        " pdfjs-dist@(§§version§§) ",
         "(?:const|var) pdfjsVersion = ['\"](§§version§§)['\"];",
         "PDFJS.version ?= ?['\"](§§version§§)['\"]",
         "apiVersion: ?['\"](§§version§§)['\"][\\s\\S]*,data(:[a-zA-Z.]{1,6})?,[\\s\\S]*password(:[a-zA-Z.]{1,10})?,[\\s\\S]*disableAutoFetch(:[a-zA-Z.]{1,22})?,[\\s\\S]*rangeChunkSize",

--- a/repository/jsrepository-v2.json
+++ b/repository/jsrepository-v2.json
@@ -7717,7 +7717,6 @@
         "/pdfjs-dist@(§§version§§)/"
       ],
       "filecontent": [
-        " pdfjs-dist@(§§version§§) ",
         "(?:const|var) pdfjsVersion = ['\"](§§version§§)['\"];",
         "PDFJS.version ?= ?['\"](§§version§§)['\"]",
         "apiVersion: ?['\"](§§version§§)['\"][\\s\\S]*,data(:[a-zA-Z.]{1,6})?,[\\s\\S]*password(:[a-zA-Z.]{1,10})?,[\\s\\S]*disableAutoFetch(:[a-zA-Z.]{1,22})?,[\\s\\S]*rangeChunkSize",

--- a/repository/jsrepository-v3.json
+++ b/repository/jsrepository-v3.json
@@ -7718,7 +7718,6 @@
           "/pdfjs-dist@(§§version§§)/"
         ],
         "filecontent": [
-          " pdfjs-dist@(§§version§§) ",
           "(?:const|var) pdfjsVersion = ['\"](§§version§§)['\"];",
           "PDFJS.version ?= ?['\"](§§version§§)['\"]",
           "apiVersion: ?['\"](§§version§§)['\"][\\s\\S]*,data(:[a-zA-Z.]{1,6})?,[\\s\\S]*password(:[a-zA-Z.]{1,10})?,[\\s\\S]*disableAutoFetch(:[a-zA-Z.]{1,22})?,[\\s\\S]*rangeChunkSize",

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -7647,7 +7647,6 @@
         "/pdfjs-dist@(§§version§§)/"
       ],
       "filecontent": [
-        " pdfjs-dist@(§§version§§) ",
         "(?:const|var) pdfjsVersion = ['\"](§§version§§)['\"];",
         "PDFJS.version ?= ?['\"](§§version§§)['\"]",
         "apiVersion: ?['\"](§§version§§)['\"][\\s\\S]*,data(:[a-zA-Z.]{1,6})?,[\\s\\S]*password(:[a-zA-Z.]{1,10})?,[\\s\\S]*disableAutoFetch(:[a-zA-Z.]{1,22})?,[\\s\\S]*rangeChunkSize",


### PR DESCRIPTION
Generic pattern with the npm style co-ordinates seems unnecessary for detection as the test cases all pass without this pattern included.

Ran all the tests prior, and also experimented with some other versions just in case. Didn't add them to the test list, as all seems OK and similar to current structures.