### PR TITLE
fix build command : add browserify directly instead of looking in node_modules/.bin

### DIFF
--- a/chrome/build/package.json
+++ b/chrome/build/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "node_modules/.bin/browserify index.js --standalone retirechrome -o ../extension/js/generated/retire-chrome.js"
+    "build": "browserify index.js --standalone retirechrome -o ../extension/js/generated/retire-chrome.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This will fix Issue #445 

since npm handles the paths for node_modules/.bin
it will automatically use the correct binary from node_modules/.bin.