### PR TITLE
docs: Update angular js deprecation URL

### DIFF
--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -2394,7 +2394,7 @@
         "severity": "low",
         "cwe": ["CWE-1104"],
         "info": [
-          "https://blog.angular.io/discontinued-long-term-support-for-angularjs-cc066b82e65a?gi=9d3103b5445c"
+          "https://docs.angularjs.org/misc/version-support-status"
         ]
       },
       {

--- a/repository/jsrepository-v2.json
+++ b/repository/jsrepository-v2.json
@@ -3309,7 +3309,7 @@
           "retid": "54"
         },
         "info": [
-          "https://blog.angular.io/discontinued-long-term-support-for-angularjs-cc066b82e65a?gi=9d3103b5445c"
+          "https://docs.angularjs.org/misc/version-support-status"
         ]
       },
       {

--- a/repository/jsrepository-v3.json
+++ b/repository/jsrepository-v3.json
@@ -3310,7 +3310,7 @@
             "retid": "54"
           },
           "info": [
-            "https://blog.angular.io/discontinued-long-term-support-for-angularjs-cc066b82e65a?gi=9d3103b5445c"
+            "https://docs.angularjs.org/misc/version-support-status"
           ]
         },
         {

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -3287,7 +3287,7 @@
           "retid": "54"
         },
         "info": [
-          "https://blog.angular.io/discontinued-long-term-support-for-angularjs-cc066b82e65a?gi=9d3103b5445c"
+          "https://docs.angularjs.org/misc/version-support-status"
         ]
       },
       {


### PR DESCRIPTION
The current URL redirects to the root of the blog (the page mentionned probably doesn't exist anymore), try to replace it by one mentioning AngularJS being EOL