### PR TITLE
AngularJS NES detection regex and vunerability db update

### DIFF
--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -2212,6 +2212,50 @@
         "ranges": [
           {
             "atOrAbove": "0",
+            "below": "1.9.9"
+          }
+        ],
+        "summary": "AngularJS Regular expression Denial of Service (ReDoS)",
+        "cwe": ["CWE-1333"],
+        "severity": "medium",
+        "identifiers": {
+          "CVE": ["CVE-2025-4690"],
+          "githubID": "GHSA-hfff-63hg-f47j"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-hfff-63hg-f47j",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-4690",
+          "https://codepen.io/herodevs/pen/RNNEPzP/751b91eab7730dff277523f3d50e4b77",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-4690"
+        ]
+      },
+      {
+        "ranges": [
+          {
+            "atOrAbove": "0",
+            "below": "1.9.8"
+          }
+        ],
+        "summary": "AngularJS Incomplete Filtering of Special Elements vulnerability",
+        "cwe": ["CWE-791"],
+        "severity": "medium",
+        "identifiers": {
+          "CVE": ["CVE-2025-2336"],
+          "githubID": "GHSA-4p4w-6hg8-63wx"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-4p4w-6hg8-63wx",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-2336",
+          "https://codepen.io/herodevs/pen/bNGYaXx/412a3a4218387479898912f60c269c6c",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-2336"
+        ]
+      },
+      {
+        "ranges": [
+          {
+            "atOrAbove": "0",
             "below": "1.8.4"
           }
         ],

--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -2579,7 +2579,7 @@
       "uri": ["/(§§version§§)/angular(\\.min)?\\.js"],
       "filename": ["angular(?:js)?-(§§version§§)(.min)?\\.js"],
       "filecontent": [
-        "/\\*[\\*\\s]+(?:@license )?AngularJS v(§§version§§)",
+        "/\\*[\\*\\s]+(?:@license )?AngularJS(?: NES)? v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {}

--- a/repository/jsrepository-v2.json
+++ b/repository/jsrepository-v2.json
@@ -3481,7 +3481,7 @@
         "angular(?:js)?-(§§version§§)(.min)?\\.js"
       ],
       "filecontent": [
-        "/\\*[\\*\\s]+(?:@license )?AngularJS v(§§version§§)",
+        "/\\*[\\*\\s]+(?:@license )?AngularJS(?: NES)? v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {},

--- a/repository/jsrepository-v2.json
+++ b/repository/jsrepository-v2.json
@@ -3437,6 +3437,50 @@
         ]
       },
       {
+        "atOrAbove": "0",
+        "below": "1.9.8",
+        "cwe": [
+          "CWE-791"
+        ],
+        "severity": "medium",
+        "identifiers": {
+          "summary": "AngularJS Incomplete Filtering of Special Elements vulnerability",
+          "CVE": [
+            "CVE-2025-2336"
+          ],
+          "githubID": "GHSA-4p4w-6hg8-63wx"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-4p4w-6hg8-63wx",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-2336",
+          "https://codepen.io/herodevs/pen/bNGYaXx/412a3a4218387479898912f60c269c6c",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-2336"
+        ]
+      },
+      {
+        "atOrAbove": "0",
+        "below": "1.9.9",
+        "cwe": [
+          "CWE-1333"
+        ],
+        "severity": "medium",
+        "identifiers": {
+          "summary": "AngularJS Regular expression Denial of Service (ReDoS)",
+          "CVE": [
+            "CVE-2025-4690"
+          ],
+          "githubID": "GHSA-hfff-63hg-f47j"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-hfff-63hg-f47j",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-4690",
+          "https://codepen.io/herodevs/pen/RNNEPzP/751b91eab7730dff277523f3d50e4b77",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-4690"
+        ]
+      },
+      {
         "below": "1.999",
         "severity": "low",
         "cwe": [

--- a/repository/jsrepository-v3.json
+++ b/repository/jsrepository-v3.json
@@ -3510,6 +3510,50 @@
           ]
         },
         {
+          "atOrAbove": "0",
+          "below": "1.9.8",
+          "cwe": [
+            "CWE-791"
+          ],
+          "severity": "medium",
+          "identifiers": {
+            "summary": "AngularJS Incomplete Filtering of Special Elements vulnerability",
+            "CVE": [
+              "CVE-2025-2336"
+            ],
+            "githubID": "GHSA-4p4w-6hg8-63wx"
+          },
+          "info": [
+            "https://github.com/advisories/GHSA-4p4w-6hg8-63wx",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-2336",
+            "https://codepen.io/herodevs/pen/bNGYaXx/412a3a4218387479898912f60c269c6c",
+            "https://github.com/angular/angular.js",
+            "https://www.herodevs.com/vulnerability-directory/cve-2025-2336"
+          ]
+        },
+        {
+          "atOrAbove": "0",
+          "below": "1.9.9",
+          "cwe": [
+            "CWE-1333"
+          ],
+          "severity": "medium",
+          "identifiers": {
+            "summary": "AngularJS Regular expression Denial of Service (ReDoS)",
+            "CVE": [
+              "CVE-2025-4690"
+            ],
+            "githubID": "GHSA-hfff-63hg-f47j"
+          },
+          "info": [
+            "https://github.com/advisories/GHSA-hfff-63hg-f47j",
+            "https://nvd.nist.gov/vuln/detail/CVE-2025-4690",
+            "https://codepen.io/herodevs/pen/RNNEPzP/751b91eab7730dff277523f3d50e4b77",
+            "https://github.com/angular/angular.js",
+            "https://www.herodevs.com/vulnerability-directory/cve-2025-4690"
+          ]
+        },
+        {
           "below": "1.999",
           "severity": "low",
           "cwe": [

--- a/repository/jsrepository-v3.json
+++ b/repository/jsrepository-v3.json
@@ -3554,7 +3554,7 @@
           "angular(?:js)?-(§§version§§)(.min)?\\.js"
         ],
         "filecontent": [
-          "/\\*[\\*\\s]+(?:@license )?AngularJS v(§§version§§)",
+          "/\\*[\\*\\s]+(?:@license )?AngularJS(?: NES)? v(§§version§§)",
           "http://errors\\.angularjs\\.org/(§§version§§)/"
         ],
         "hashes": {},

--- a/repository/jsrepository-v4.json
+++ b/repository/jsrepository-v4.json
@@ -3509,6 +3509,50 @@
         ]
       },
       {
+        "atOrAbove": "0",
+        "below": "1.9.8",
+        "cwe": [
+          "CWE-791"
+        ],
+        "severity": "medium",
+        "identifiers": {
+          "summary": "AngularJS Incomplete Filtering of Special Elements vulnerability",
+          "CVE": [
+            "CVE-2025-2336"
+          ],
+          "githubID": "GHSA-4p4w-6hg8-63wx"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-4p4w-6hg8-63wx",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-2336",
+          "https://codepen.io/herodevs/pen/bNGYaXx/412a3a4218387479898912f60c269c6c",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-2336"
+        ]
+      },
+      {
+        "atOrAbove": "0",
+        "below": "1.9.9",
+        "cwe": [
+          "CWE-1333"
+        ],
+        "severity": "medium",
+        "identifiers": {
+          "summary": "AngularJS Regular expression Denial of Service (ReDoS)",
+          "CVE": [
+            "CVE-2025-4690"
+          ],
+          "githubID": "GHSA-hfff-63hg-f47j"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-hfff-63hg-f47j",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-4690",
+          "https://codepen.io/herodevs/pen/RNNEPzP/751b91eab7730dff277523f3d50e4b77",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-4690"
+        ]
+      },
+      {
         "below": "1.999",
         "severity": "low",
         "cwe": [

--- a/repository/jsrepository-v4.json
+++ b/repository/jsrepository-v4.json
@@ -3553,7 +3553,7 @@
         "angular(?:js)?-(§§version§§)(.min)?\\.js"
       ],
       "filecontent": [
-        "/\\*[\\*\\s]+(?:@license )?AngularJS v(§§version§§)",
+        "/\\*[\\*\\s]+(?:@license )?AngularJS(?: NES)? v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {},

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -3410,6 +3410,50 @@
         ]
       },
       {
+        "atOrAbove": "0",
+        "below": "1.9.8",
+        "cwe": [
+          "CWE-791"
+        ],
+        "severity": "medium",
+        "identifiers": {
+          "summary": "AngularJS Incomplete Filtering of Special Elements vulnerability",
+          "CVE": [
+            "CVE-2025-2336"
+          ],
+          "githubID": "GHSA-4p4w-6hg8-63wx"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-4p4w-6hg8-63wx",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-2336",
+          "https://codepen.io/herodevs/pen/bNGYaXx/412a3a4218387479898912f60c269c6c",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-2336"
+        ]
+      },
+      {
+        "atOrAbove": "0",
+        "below": "1.9.9",
+        "cwe": [
+          "CWE-1333"
+        ],
+        "severity": "medium",
+        "identifiers": {
+          "summary": "AngularJS Regular expression Denial of Service (ReDoS)",
+          "CVE": [
+            "CVE-2025-4690"
+          ],
+          "githubID": "GHSA-hfff-63hg-f47j"
+        },
+        "info": [
+          "https://github.com/advisories/GHSA-hfff-63hg-f47j",
+          "https://nvd.nist.gov/vuln/detail/CVE-2025-4690",
+          "https://codepen.io/herodevs/pen/RNNEPzP/751b91eab7730dff277523f3d50e4b77",
+          "https://github.com/angular/angular.js",
+          "https://www.herodevs.com/vulnerability-directory/cve-2025-4690"
+        ]
+      },
+      {
         "below": "1.999",
         "severity": "low",
         "cwe": [

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -3454,7 +3454,7 @@
         "angular(?:js)?-(§§version§§)(.min)?\\.js"
       ],
       "filecontent": [
-        "/\\*[\\*\\s]+(?:@license )?AngularJS v(§§version§§)",
+        "/\\*[\\*\\s]+(?:@license )?AngularJS(?: NES)? v(§§version§§)",
         "http://errors\\.angularjs\\.org/(§§version§§)/"
       ],
       "hashes": {}


### PR DESCRIPTION
The following vulnerable code was not being detected:


```
/**
 * @license AngularJS NES v1.9.7
 * (c) 2023 HeroDevs, Inc.
 * Released under the HeroDevs NES License.
 */
/**
```

I have included two commits.

1. Adjust the regex to detect optional NES field
2. Update the CVE database with two recently reported vulnerabilities.