### PR TITLE
Bootstrap 4.1.1 vulnerability (CVE-2024-6531) was retired in August 2025

### DIFF
--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -3986,12 +3986,6 @@
         ]
       },
       {
-        "ranges": [
-          {
-            "atOrAbove": "4.0.0",
-            "below": "5.0.0"
-          }
-        ],
         "summary": "Bootstrap Cross-Site Scripting (XSS) vulnerability",
         "cwe": ["CWE-79"],
         "severity": "medium",
@@ -3999,7 +3993,9 @@
           "CVE": ["CVE-2024-6531"],
           "githubID": "GHSA-vc8w-jr9v-vj7f"
         },
-        "info": [
+       "withdrawn": true,
+       "note": "CVE-2024-6531 withdrawn (REJECTED by NVD on 2025-09-01). Previously affected Bootstrap 4.1.1–4.3.0.",
+       "info": [
           "https://github.com/advisories/GHSA-vc8w-jr9v-vj7f",
           "https://nvd.nist.gov/vuln/detail/CVE-2024-6531",
           "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/bootstrap/CVE-2024-6531.yml",


### PR DESCRIPTION
### Summary
This PR updates `jsrepository.json` to mark `CVE-2024-6531` (Bootstrap 4.1.1) as **withdrawn**, since the NVD lists it as REJECTED (2025-09-01).

### Changes
- Added `"withdrawn": true` and a `note` field to document the CVE status.
- Removed version range fields to avoid false positives.

### Reference
https://nvd.nist.gov/vuln/detail/CVE-2024-6531

Fixes RetireJS/retire.js#488