### PR TITLE
Add ability to have exclusions, and add one for jquery 1.12.4-aem

### DIFF
--- a/node/lib/retire.js
+++ b/node/lib/retire.js
@@ -103,6 +103,9 @@ function check(results, repo) {
         if (isDefined(vulns[i].atOrAbove) && !isAtOrAbove(result.version, vulns[i].atOrAbove)) {
           continue;
         }
+        if (isDefined(vulns[i].excludes) && vulns[i].excludes.indexOf(result.version) !== -1) {
+          continue;
+        }
         var vulnerability = { info: vulns[i].info, below: vulns[i].below, atOrAbove: vulns[i].atOrAbove };
         if (vulns[i].severity) {
           vulnerability.severity = vulns[i].severity;

--- a/node/spec/tests/versions.spec.ts
+++ b/node/spec/tests/versions.spec.ts
@@ -67,4 +67,16 @@ describe('versions', function () {
     assert.isNotVulnerable(result);
     done();
   });
+  it('should_not_be_vulnerable_when_version_in_excludes_list', function (done) {
+    repo.jquery.vulnerabilities = [{ atOrAbove: '1.0.0', below: '3.0.0', excludes: ['1.12.4-aem'] }];
+    const result = retire.scanUri('https://ajax.googleapis.com/ajax/libs/jquery/1.12.4-aem/jquery.min.js', repo);
+    assert.isNotVulnerable(result);
+    done();
+  });
+  it('should_be_vulnerable_when_similar_version_not_in_excludes_list', function (done) {
+    repo.jquery.vulnerabilities = [{ atOrAbove: '1.0.0', below: '3.0.0', excludes: ['1.12.4-aem'] }];
+    const result = retire.scanUri('https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js', repo);
+    assert.isVulnerable(result);
+    done();
+  });
 });

--- a/node/src/repo.ts
+++ b/node/src/repo.ts
@@ -21,6 +21,7 @@ export function validateRepository(
     .object({
       below: versionValidator,
       atOrAbove: versionValidator.optional(),
+      excludes: z.array(versionValidator).optional(),
       severity: z.enum(keys),
       cwe: z.array(z.string().regex(/^CWE-[0-9]+$/)).min(1),
       identifiers: z

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -23,6 +23,7 @@ export type Repository = Record<
 export type Vulnerability = {
   below: string;
   atOrAbove?: string;
+  excludes?: string[];
   severity: SeverityLevel;
   cwe: string[];
   identifiers: {

--- a/repository/convertFormat.js
+++ b/repository/convertFormat.js
@@ -28,12 +28,16 @@ function convertToOldFormat(
       const { ranges, summary, identifiers, info, ...rest } = v;
 
       ranges.forEach((r) => {
-        vulns.push({
+        const vuln = {
           ...r,
           ...rest,
           identifiers: { summary, ...identifiers },
           info,
-        });
+        };
+        if (r.excludes) {
+          vuln.excludes = r.excludes;
+        }
+        vulns.push(vuln);
       });
     });
     vulns.sort((a, b) => {

--- a/repository/jsrepository-master.json
+++ b/repository/jsrepository-master.json
@@ -98,7 +98,8 @@
           },
           {
             "atOrAbove": "1.12.3",
-            "below": "3.0.0-beta1"
+            "below": "3.0.0-beta1",
+            "excludes": ["1.12.4-aem"]
           }
         ],
         "summary": "3rd party CORS request may execute",
@@ -138,7 +139,8 @@
         "ranges": [
           {
             "atOrAbove": "1.1.4",
-            "below": "3.4.0"
+            "below": "3.4.0",
+            "excludes": ["1.12.4-aem"]
           }
         ],
         "summary": "jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution",
@@ -159,7 +161,8 @@
         "ranges": [
           {
             "atOrAbove": "1.2.0",
-            "below": "3.5.0"
+            "below": "3.5.0",
+            "excludes": ["1.12.4-aem"]
           }
         ],
         "summary": "Regex in its jQuery.htmlPrefilter sometimes may introduce XSS",
@@ -176,7 +179,8 @@
         "ranges": [
           {
             "atOrAbove": "1.0.3",
-            "below": "3.5.0"
+            "below": "3.5.0",
+            "excludes": ["1.12.4-aem"]
           }
         ],
         "summary": "passing HTML containing <option> elements from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code.",
@@ -192,7 +196,8 @@
       {
         "ranges": [
           {
-            "below": "2.999.999"
+            "below": "2.999.999",
+            "excludes": ["1.12.4-aem"]
           }
         ],
         "summary": "jQuery 1.x and 2.x are End-of-Life and no longer receiving security updates",

--- a/repository/jsrepository-v2.json
+++ b/repository/jsrepository-v2.json
@@ -126,6 +126,9 @@
       },
       {
         "below": "2.999.999",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-1104"
         ],
@@ -142,6 +145,9 @@
       {
         "atOrAbove": "1.12.3",
         "below": "3.0.0-beta1",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],
@@ -185,6 +191,9 @@
       {
         "atOrAbove": "1.1.4",
         "below": "3.4.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-1321",
           "CWE-79"
@@ -207,6 +216,9 @@
       {
         "atOrAbove": "1.0.3",
         "below": "3.5.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],
@@ -226,6 +238,9 @@
       {
         "atOrAbove": "1.2.0",
         "below": "3.5.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],

--- a/repository/jsrepository-v3.json
+++ b/repository/jsrepository-v3.json
@@ -133,6 +133,9 @@
         },
         {
           "below": "2.999.999",
+          "excludes": [
+            "1.12.4-aem"
+          ],
           "cwe": [
             "CWE-1104"
           ],
@@ -149,6 +152,9 @@
         {
           "atOrAbove": "1.12.3",
           "below": "3.0.0-beta1",
+          "excludes": [
+            "1.12.4-aem"
+          ],
           "cwe": [
             "CWE-79"
           ],
@@ -192,6 +198,9 @@
         {
           "atOrAbove": "1.1.4",
           "below": "3.4.0",
+          "excludes": [
+            "1.12.4-aem"
+          ],
           "cwe": [
             "CWE-1321",
             "CWE-79"
@@ -214,6 +223,9 @@
         {
           "atOrAbove": "1.0.3",
           "below": "3.5.0",
+          "excludes": [
+            "1.12.4-aem"
+          ],
           "cwe": [
             "CWE-79"
           ],
@@ -233,6 +245,9 @@
         {
           "atOrAbove": "1.2.0",
           "below": "3.5.0",
+          "excludes": [
+            "1.12.4-aem"
+          ],
           "cwe": [
             "CWE-79"
           ],

--- a/repository/jsrepository-v4.json
+++ b/repository/jsrepository-v4.json
@@ -132,6 +132,9 @@
       },
       {
         "below": "2.999.999",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-1104"
         ],
@@ -148,6 +151,9 @@
       {
         "atOrAbove": "1.12.3",
         "below": "3.0.0-beta1",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],
@@ -191,6 +197,9 @@
       {
         "atOrAbove": "1.1.4",
         "below": "3.4.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-1321",
           "CWE-79"
@@ -213,6 +222,9 @@
       {
         "atOrAbove": "1.0.3",
         "below": "3.5.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],
@@ -232,6 +244,9 @@
       {
         "atOrAbove": "1.2.0",
         "below": "3.5.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],

--- a/repository/jsrepository.json
+++ b/repository/jsrepository.json
@@ -126,6 +126,9 @@
       },
       {
         "below": "2.999.999",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-1104"
         ],
@@ -142,6 +145,9 @@
       {
         "atOrAbove": "1.12.3",
         "below": "3.0.0-beta1",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],
@@ -185,6 +191,9 @@
       {
         "atOrAbove": "1.1.4",
         "below": "3.4.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-1321",
           "CWE-79"
@@ -207,6 +216,9 @@
       {
         "atOrAbove": "1.0.3",
         "below": "3.5.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],
@@ -226,6 +238,9 @@
       {
         "atOrAbove": "1.2.0",
         "below": "3.5.0",
+        "excludes": [
+          "1.12.4-aem"
+        ],
         "cwe": [
           "CWE-79"
         ],


### PR DESCRIPTION
At Bright Security, we've encountered a situation where retirejs incorrectly identifies a version of jquery as vulnerable when it is not.

The standard jquery version 1.12.4 is vulnerable to several CVEs. However, Adobe maintains a patched version (1.12.4-aem) that is not vulnerable.

This change adds the ability to exclude certain results from positive matches, so that patched versions of vulnerable libraries don't cause false positives. This capability is used to exclude jquery 1.12.4-aem, which is a version patched by Adobe to fix the vulnerabilities that exist in 1.12.4.

I have also added some tests for the functionality.

I didn't see any contributing guidelines, so please let me know if you have any questions, or if there is anything that you would like to see changed.