### PR TITLE
Fix XSS in Chrome extension popup via unsanitized URL in innerHTML

### DIFF
--- a/chrome/extension/js/popup.js
+++ b/chrome/extension/js/popup.js
@@ -147,13 +147,13 @@ function show(totalResults) {
       td(tr).innerText = "-";
       td(tr).innerText = "-";
       vulns = td(tr);
-      vulns.innerHTML = `Did not recognize ${r.url}`;
+      vulns.textContent = `Did not recognize ${r.url}`;
     } else {
       td(tr).innerText = r.component;
       td(tr).innerText = r.version;
       vulns = td(tr);
       let d = detMapping[r.detection] ?? r.detection;
-      vulns.innerHTML = `${r.url} (${d} detection)`;
+      vulns.textContent = `${r.url} (${d} detection)`;
     }
     if (r.vulnerabilities && r.vulnerabilities.length > 0) {
       r.vulnerabilities.sort((x, y) => {


### PR DESCRIPTION
## Summary

The Chrome extension popup (`chrome/extension/js/popup.js`) injects resource URLs directly into the DOM via `innerHTML` at lines 150 and 156 without any sanitization. A malicious web page can load a script from a URL containing HTML payloads (e.g., `https://evil.com/<img src=x onerror=alert(1)>/lib.js`), which would execute JavaScript in the extension popup context when the user opens it.

## Changes

- **Line 150:** `vulns.innerHTML` → `vulns.textContent` (unknown component URL display)
- **Line 156:** `vulns.innerHTML` → `vulns.textContent` (detected component URL display)

`textContent` safely renders the URL as plain text, preventing any embedded HTML from being parsed and executed. The visible output remains identical for legitimate URLs.

## Impact

Prevents Cross-Site Scripting (XSS) in the Chrome extension popup. Since the popup runs with extension privileges, exploitation could allow access to extension APIs and browsing data.

## Related

- GHSA-6pq9-xpx7-2j8p