### PR TITLE
fix: allow array-based identifiers in ignore file

### DIFF
--- a/node/src/cli.ts
+++ b/node/src/cli.ts
@@ -146,7 +146,7 @@ const ignoreFileParser = z.array(
           z.object({
             component: z.string(),
             version: z.string().optional(),
-            identifiers: z.record(z.string(), z.string()).optional(),
+            identifiers: z.record(z.string(), z.string().or(z.array(z.string()))).optional(),
           }),
         ),
     ),

--- a/node/src/scanner.ts
+++ b/node/src/scanner.ts
@@ -112,7 +112,9 @@ function removeIgnoredVulnerabilitiesByIdentifier(identifiers: Record<string, st
 function hasIdentifier(identifiers: Record<string, string | string[]>, key: string, value: string | string[]) {
   if (!(key in identifiers)) return false;
   const identifier = identifiers[key];
-  return Array.isArray(identifier) ? identifier.some((x) => x === value) : identifier === value;
+  const identifierArr = Array.isArray(identifier) ? identifier : [identifier];
+  const valueArr = Array.isArray(value) ? value : [value];
+  return identifierArr.some((id) => valueArr.includes(id));
 }
 
 export function scanJsFile(file: string, repo: Repository, options: Options) {


### PR DESCRIPTION
The `.retireignore.json` schema in `node/src/cli.ts` was overly restrictive, only allowing single string values for identifiers in the ignore configuration. This prevented users from ignoring vulnerabilities that are identified by arrays (e.g., CVE lists) in the vulnerability repository. This change updates the Zod schema in `node/src/cli.ts` to support both string and array-of-strings values for identifiers, and updates the `hasIdentifier` function in `node/src/scanner.ts` to correctly handle array-based comparisons. This ensures that the ignore logic properly matches vulnerabilities even when multiple identifiers are provided or when the vulnerability repository uses array-based identifiers.